### PR TITLE
Add config-driven local UI runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,119 @@
 # LocalUI
-Local WebUI for system apps
+
+LocalUI is a tiny PHP web interface that renders controls defined in JSON and safely executes whitelisted shell commands on your machine. It is intended for localhost use with the built-in PHP server.
+
+## Requirements
+- PHP 8.1 or newer with `proc_open` enabled
+- Web browser with JavaScript enabled
+
+## Setup
+1. Clone this repository or download the sources.
+2. Copy the sample UI configuration to `config/ui.json` and adjust to your needs:
+   ```sh
+   cp config/ui.sample.json config/ui.json
+   ```
+3. Update the whitelist and element command templates in `config/ui.json` to match the binaries you intend to run.
+
+## Running the web server
+```sh
+php -S localhost:8000 -t public
+```
+Then open [http://localhost:8000](http://localhost:8000) in your browser.
+
+## API endpoints
+- `POST /api/run` — Trigger a command. Payload example: `{ "id": "envOut", "commandId": "printEnv", "args": { "value": "optional" } }`
+- `GET /api/read?id=envOut` — Read the most recently stored result for the given element or command.
+
+Responses include:
+```json
+{
+  "ok": true,
+  "commandId": "printEnv",
+  "id": "envOut",
+  "result": {
+    "ok": true,
+    "code": 0,
+    "stdout": "...",
+    "stderr": "",
+    "ts": "2024-01-01T12:00:00+00:00"
+  }
+}
+```
+
+## Configuration schema
+Create `config/ui.json` following the structure below. Each element describes a control rendered by the UI. Commands with `${value}` placeholders are substituted with runtime values and executed only if the binary is present in the whitelist.
+
+```json
+{
+  "globals": {
+    "theme": {
+      "palette": { "primary": "#111827", "accent": "#10B981" },
+      "font": "Inter",
+      "margins": 12,
+      "gap": 8,
+      "layout": "grid"
+    },
+    "defaults": { "w": 12, "h": 2, "classes": "" }
+  },
+  "elements": [
+    {
+      "id": "btnCat",
+      "type": "button",
+      "label": "View /etc/hosts",
+      "command": { "server": { "id": "catHosts", "template": "cat /etc/hosts" } },
+      "tooltip": "Show hosts file",
+      "w": 6
+    },
+    {
+      "id": "mute",
+      "type": "toggle",
+      "label": "Mute",
+      "onCommand": { "server": { "id": "mute", "template": "pactl set-sink-mute @DEFAULT_SINK@ 1" } },
+      "offCommand": { "server": { "id": "unmute", "template": "pactl set-sink-mute @DEFAULT_SINK@ 0" } },
+      "initial": false
+    },
+    {
+      "id": "stepVol",
+      "type": "stepper",
+      "label": "Volume",
+      "min": 0,
+      "max": 150,
+      "step": 5,
+      "value": 50,
+      "command": { "server": { "id": "setVol", "template": "pactl set-sink-volume @DEFAULT_SINK@ ${value}%" } }
+    },
+    {
+      "id": "inpFile",
+      "type": "input",
+      "label": "File path",
+      "inputType": "string",
+      "apply": { "label": "Apply", "command": { "server": { "id": "catFile", "template": "cat ${value}" } } }
+    },
+    {
+      "id": "envOut",
+      "type": "output",
+      "label": "Environment",
+      "command": { "server": { "id": "printEnv", "template": "env" } },
+      "mode": "poll",
+      "intervalMs": 3000,
+      "w": 12,
+      "h": 6
+    },
+    {
+      "id": "fastfetch",
+      "type": "output",
+      "label": "Fastfetch",
+      "command": { "server": { "id": "fastfetch", "template": "fastfetch --logo none" } },
+      "mode": "manual",
+      "onDemandButtonLabel": "Refresh"
+    }
+  ],
+  "whitelist": ["cat", "env", "fastfetch", "pactl"]
+}
+```
+
+## Notes
+- Only binaries listed in `whitelist` are executed. The server resolves binaries via the `PATH` environment.
+- Arguments with forbidden shell metacharacters are rejected before execution.
+- Command results are cached in `data/*.json` so they can be retrieved via `GET /api/read`.
+- The UI polls output widgets automatically when `mode` is set to `"poll"`.

--- a/api/index.php
+++ b/api/index.php
@@ -1,0 +1,91 @@
+<?php
+require_once __DIR__ . '/../lib/Core.php';
+require_once __DIR__ . '/../lib/Exec.php';
+
+try {
+    Core::init();
+} catch (Throwable $e) {
+    Core::sendError($e->getMessage(), 500);
+}
+
+$method = $_SERVER['REQUEST_METHOD'] ?? 'GET';
+$uriPath = parse_url($_SERVER['REQUEST_URI'] ?? '/', PHP_URL_PATH);
+$base = rtrim(dirname($_SERVER['SCRIPT_NAME'] ?? ''), '/');
+if ($base !== '' && str_starts_with($uriPath, $base)) {
+    $uriPath = substr($uriPath, strlen($base));
+}
+$uriPath = '/' . ltrim($uriPath, '/');
+
+switch ($method) {
+    case 'POST':
+        if ($uriPath === '/run') {
+            handle_run();
+            break;
+        }
+        break;
+    case 'GET':
+        if ($uriPath === '/read') {
+            handle_read();
+            break;
+        }
+        break;
+}
+
+Core::sendError('Not Found', 404);
+
+function handle_run(): void
+{
+    $raw = file_get_contents('php://input');
+    $payload = json_decode($raw, true);
+    if (!is_array($payload)) {
+        Core::sendError('Invalid JSON payload.');
+    }
+
+    $elementId = isset($payload['id']) ? Defaults::sanitizeId((string) $payload['id']) : '';
+    $commandId = isset($payload['commandId']) ? Defaults::sanitizeId((string) $payload['commandId']) : '';
+    $args = isset($payload['args']) && is_array($payload['args']) ? $payload['args'] : [];
+
+    if ($commandId === '') {
+        Core::sendError('commandId is required.');
+    }
+
+    $command = Core::getCommand($commandId);
+    if (!$command) {
+        Core::sendError('Unknown command: ' . $commandId, 404);
+    }
+
+    $config = Core::getConfig();
+
+    try {
+        $result = Exec::run($command, $args, $config);
+    } catch (Throwable $e) {
+        Core::sendError($e->getMessage(), 400, ['commandId' => $commandId]);
+    }
+
+    $record = [
+        'ok' => $result['ok'],
+        'commandId' => $commandId,
+        'id' => $elementId !== '' ? $elementId : null,
+        'result' => $result,
+    ];
+
+    $storeId = $elementId !== '' ? $elementId : $commandId;
+    Core::storeResult($storeId, $record);
+
+    Core::sendJson($record);
+}
+
+function handle_read(): void
+{
+    $id = isset($_GET['id']) ? Defaults::sanitizeId((string) $_GET['id']) : '';
+    if ($id === '') {
+        Core::sendError('id is required.');
+    }
+
+    $record = Core::readResult($id);
+    if (!$record) {
+        Core::sendError('No stored result for id: ' . $id, 404);
+    }
+
+    Core::sendJson($record);
+}

--- a/config/ui.sample.json
+++ b/config/ui.sample.json
@@ -1,0 +1,66 @@
+{
+  "globals": {
+    "theme": {
+      "palette": { "primary": "#111827", "accent": "#10B981" },
+      "font": "Inter",
+      "margins": 12,
+      "gap": 8,
+      "layout": "grid"
+    },
+    "defaults": { "w": 12, "h": 2, "classes": "" }
+  },
+  "elements": [
+    {
+      "id": "btnCat",
+      "type": "button",
+      "label": "View /etc/hosts",
+      "command": { "server": { "id": "catHosts", "template": "cat /etc/hosts" } },
+      "tooltip": "Show hosts file",
+      "w": 6
+    },
+    {
+      "id": "mute",
+      "type": "toggle",
+      "label": "Mute",
+      "onCommand": { "server": { "id": "mute", "template": "pactl set-sink-mute @DEFAULT_SINK@ 1" } },
+      "offCommand": { "server": { "id": "unmute", "template": "pactl set-sink-mute @DEFAULT_SINK@ 0" } },
+      "initial": false
+    },
+    {
+      "id": "stepVol",
+      "type": "stepper",
+      "label": "Volume",
+      "min": 0,
+      "max": 150,
+      "step": 5,
+      "value": 50,
+      "command": { "server": { "id": "setVol", "template": "pactl set-sink-volume @DEFAULT_SINK@ ${value}%" } }
+    },
+    {
+      "id": "inpFile",
+      "type": "input",
+      "label": "File path",
+      "inputType": "string",
+      "apply": { "label": "Apply", "command": { "server": { "id": "catFile", "template": "cat ${value}" } } }
+    },
+    {
+      "id": "envOut",
+      "type": "output",
+      "label": "Environment",
+      "command": { "server": { "id": "printEnv", "template": "env" } },
+      "mode": "poll",
+      "intervalMs": 3000,
+      "w": 12,
+      "h": 6
+    },
+    {
+      "id": "fastfetch",
+      "type": "output",
+      "label": "Fastfetch",
+      "command": { "server": { "id": "fastfetch", "template": "fastfetch --logo none" } },
+      "mode": "manual",
+      "onDemandButtonLabel": "Refresh"
+    }
+  ],
+  "whitelist": ["cat", "env", "fastfetch", "pactl"]
+}

--- a/lib/Core.php
+++ b/lib/Core.php
@@ -1,0 +1,120 @@
+<?php
+
+require_once __DIR__ . '/Defaults.php';
+require_once __DIR__ . '/Elements.php';
+
+class Core
+{
+    private static array $config = [];
+    private static array $commands = [];
+
+    public static function init(?string $path = null): void
+    {
+        if (!empty(self::$config)) {
+            return;
+        }
+        self::loadConfig($path);
+    }
+
+    public static function loadConfig(?string $path = null): array
+    {
+        $base = Defaults::baseConfig();
+        $configPath = $path ?? __DIR__ . '/../config/ui.json';
+        $fallbackPath = __DIR__ . '/../config/ui.sample.json';
+
+        $raw = null;
+        if (is_file($configPath)) {
+            $raw = file_get_contents($configPath);
+        } elseif (is_file($fallbackPath)) {
+            $raw = file_get_contents($fallbackPath);
+        }
+
+        $data = [];
+        if ($raw !== null) {
+            $data = json_decode($raw, true);
+            if (!is_array($data)) {
+                throw new RuntimeException('Unable to parse UI configuration JSON.');
+            }
+        }
+
+        $globals = $base['globals'];
+        if (isset($data['globals']) && is_array($data['globals'])) {
+            $globals = array_replace_recursive($globals, $data['globals']);
+        }
+
+        $elements = $data['elements'] ?? [];
+        [$normalized, $commands] = Elements::normalize($elements, $globals);
+
+        $whitelist = [];
+        if (isset($data['whitelist']) && is_array($data['whitelist'])) {
+            $whitelist = array_values(array_unique(array_map('strval', $data['whitelist'])));
+        }
+
+        self::$config = [
+            'globals' => $globals,
+            'elements' => $normalized,
+            'whitelist' => $whitelist,
+        ];
+        self::$commands = $commands;
+
+        return self::$config;
+    }
+
+    public static function getConfig(): array
+    {
+        if (empty(self::$config)) {
+            self::init();
+        }
+        return self::$config;
+    }
+
+    public static function getCommand(string $commandId): ?array
+    {
+        if (empty(self::$commands)) {
+            self::init();
+        }
+        return self::$commands[$commandId] ?? null;
+    }
+
+    public static function sendJson($data, int $status = 200): void
+    {
+        http_response_code($status);
+        header('Content-Type: application/json');
+        echo json_encode($data, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
+        exit;
+    }
+
+    public static function sendError(string $message, int $status = 400, array $extra = []): void
+    {
+        $payload = array_merge(['ok' => false, 'error' => $message], $extra);
+        self::sendJson($payload, $status);
+    }
+
+    public static function storageDir(): string
+    {
+        $dir = __DIR__ . '/../data';
+        if (!is_dir($dir)) {
+            mkdir($dir, 0775, true);
+        }
+        return realpath($dir) ?: $dir;
+    }
+
+    public static function storeResult(string $id, array $result): void
+    {
+        $safe = Defaults::sanitizeId($id);
+        $path = self::storageDir() . '/' . $safe . '.json';
+        file_put_contents($path, json_encode($result, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT));
+    }
+
+    public static function readResult(string $id): ?array
+    {
+        $safe = Defaults::sanitizeId($id);
+        $path = self::storageDir() . '/' . $safe . '.json';
+        if (!is_file($path)) {
+            return null;
+        }
+        $raw = file_get_contents($path);
+        $data = json_decode($raw, true);
+        return is_array($data) ? $data : null;
+    }
+}

--- a/lib/Defaults.php
+++ b/lib/Defaults.php
@@ -1,0 +1,37 @@
+<?php
+
+class Defaults
+{
+    public static function baseConfig(): array
+    {
+        return [
+            'globals' => [
+                'theme' => [
+                    'palette' => [
+                        'primary' => '#111827',
+                        'accent' => '#10B981',
+                        'surface' => '#F8FAFC',
+                        'muted' => '#64748B',
+                        'danger' => '#DC2626',
+                    ],
+                    'font' => 'Inter, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif',
+                    'margins' => 12,
+                    'gap' => 8,
+                    'layout' => 'grid',
+                ],
+                'defaults' => [
+                    'w' => 12,
+                    'h' => 2,
+                    'classes' => '',
+                ],
+            ],
+            'elements' => [],
+            'whitelist' => [],
+        ];
+    }
+
+    public static function sanitizeId(string $id): string
+    {
+        return preg_replace('/[^A-Za-z0-9_\-]/', '_', $id);
+    }
+}

--- a/lib/Elements.php
+++ b/lib/Elements.php
@@ -1,0 +1,189 @@
+<?php
+
+require_once __DIR__ . '/Defaults.php';
+
+class Elements
+{
+    private const SUPPORTED_TYPES = ['button', 'toggle', 'stepper', 'input', 'output'];
+
+    public static function normalize(array $elements, array $globals): array
+    {
+        $normalized = [];
+        $commands = [];
+        $ids = [];
+        foreach ($elements as $element) {
+            if (!is_array($element)) {
+                throw new InvalidArgumentException('Element definition must be an object.');
+            }
+            if (empty($element['id']) || empty($element['type'])) {
+                throw new InvalidArgumentException('Each element requires an id and type.');
+            }
+            $element['id'] = Defaults::sanitizeId((string) $element['id']);
+            if (!in_array($element['type'], self::SUPPORTED_TYPES, true)) {
+                throw new InvalidArgumentException('Unsupported element type: ' . $element['type']);
+            }
+            if (isset($ids[$element['id']])) {
+                throw new InvalidArgumentException('Duplicate element id: ' . $element['id']);
+            }
+            $ids[$element['id']] = true;
+
+            $element = self::applyDefaults($element, $globals);
+            $normalized[] = $element;
+            foreach (self::collectCommands($element) as $command) {
+                $commands[$command['id']] = $command;
+            }
+        }
+
+        return [$normalized, $commands];
+    }
+
+    private static function applyDefaults(array $element, array $globals): array
+    {
+        $defaults = $globals['defaults'] ?? [];
+        foreach ($defaults as $key => $value) {
+            if (!isset($element[$key])) {
+                $element[$key] = $value;
+            }
+        }
+
+        if (!isset($element['classes'])) {
+            $element['classes'] = '';
+        }
+        if (!empty($defaults['classes']) && strpos($element['classes'], $defaults['classes']) === false) {
+            $element['classes'] = trim($element['classes'] . ' ' . $defaults['classes']);
+        }
+
+        switch ($element['type']) {
+            case 'button':
+                $element['label'] = $element['label'] ?? $element['id'];
+                if (isset($element['command'])) {
+                    $element['command'] = self::normalizeCommandWrapper($element['command'], $element['id'], 'button');
+                }
+                break;
+            case 'toggle':
+                $element['label'] = $element['label'] ?? $element['id'];
+                $element['initial'] = (bool) ($element['initial'] ?? false);
+                if (isset($element['onCommand'])) {
+                    $element['onCommand'] = self::normalizeCommandWrapper($element['onCommand'], $element['id'], 'on');
+                }
+                if (isset($element['offCommand'])) {
+                    $element['offCommand'] = self::normalizeCommandWrapper($element['offCommand'], $element['id'], 'off');
+                }
+                break;
+            case 'stepper':
+                $element['label'] = $element['label'] ?? $element['id'];
+                $element['min'] = isset($element['min']) ? (int) $element['min'] : 0;
+                $element['max'] = isset($element['max']) ? (int) $element['max'] : 100;
+                $element['step'] = isset($element['step']) ? (int) $element['step'] : 1;
+                $element['value'] = isset($element['value']) ? (int) $element['value'] : $element['min'];
+                if ($element['value'] < $element['min']) {
+                    $element['value'] = $element['min'];
+                }
+                if ($element['value'] > $element['max']) {
+                    $element['value'] = $element['max'];
+                }
+                if (isset($element['command'])) {
+                    $element['command'] = self::normalizeCommandWrapper($element['command'], $element['id'], 'stepper');
+                }
+                break;
+            case 'input':
+                $element['label'] = $element['label'] ?? $element['id'];
+                $element['inputType'] = $element['inputType'] ?? 'string';
+                if (isset($element['apply'])) {
+                    $element['apply'] = self::normalizeApply($element['apply'], $element['id']);
+                }
+                break;
+            case 'output':
+                $element['label'] = $element['label'] ?? $element['id'];
+                $element['mode'] = $element['mode'] ?? 'manual';
+                $element['intervalMs'] = isset($element['intervalMs']) ? (int) $element['intervalMs'] : 5000;
+                if (isset($element['command'])) {
+                    $element['command'] = self::normalizeCommandWrapper($element['command'], $element['id'], 'output');
+                }
+                if (!isset($element['onDemandButtonLabel'])) {
+                    $element['onDemandButtonLabel'] = 'Refresh';
+                }
+                if (!isset($element['h'])) {
+                    $element['h'] = 4;
+                }
+                break;
+        }
+
+        return $element;
+    }
+
+    private static function normalizeCommandWrapper(array $commandWrapper, string $elementId, string $suffix): array
+    {
+        if (isset($commandWrapper['server'])) {
+            $commandWrapper['server'] = self::normalizeServerCommand($commandWrapper['server'], $elementId, $suffix);
+        } elseif (isset($commandWrapper['template'])) {
+            $commandWrapper = [
+                'server' => self::normalizeServerCommand($commandWrapper, $elementId, $suffix),
+            ];
+        }
+
+        if (isset($commandWrapper['client']) && is_array($commandWrapper['client'])) {
+            if (!isset($commandWrapper['client']['script'])) {
+                throw new InvalidArgumentException('Client command requires a script field.');
+            }
+            $commandWrapper['client']['script'] = (string) $commandWrapper['client']['script'];
+        }
+
+        return $commandWrapper;
+    }
+
+    private static function normalizeServerCommand(array $command, string $elementId, string $suffix): array
+    {
+        if (empty($command['template'])) {
+            throw new InvalidArgumentException('Server command template cannot be empty for element ' . $elementId);
+        }
+        $command['template'] = trim((string) $command['template']);
+        $command['id'] = Defaults::sanitizeId($command['id'] ?? ($elementId . '_' . $suffix));
+
+        return $command;
+    }
+
+    private static function normalizeApply(array $apply, string $elementId): array
+    {
+        $apply['label'] = $apply['label'] ?? 'Apply';
+        if (isset($apply['command'])) {
+            $apply['command'] = self::normalizeCommandWrapper($apply['command'], $elementId, 'input');
+        }
+        return $apply;
+    }
+
+    private static function collectCommands(array $element): array
+    {
+        $commands = [];
+        $candidates = [];
+
+        switch ($element['type']) {
+            case 'button':
+                $candidates[] = $element['command'] ?? null;
+                break;
+            case 'toggle':
+                $candidates[] = $element['onCommand'] ?? null;
+                $candidates[] = $element['offCommand'] ?? null;
+                break;
+            case 'stepper':
+                $candidates[] = $element['command'] ?? null;
+                break;
+            case 'input':
+                if (isset($element['apply'])) {
+                    $candidates[] = $element['apply']['command'] ?? null;
+                }
+                break;
+            case 'output':
+                $candidates[] = $element['command'] ?? null;
+                break;
+        }
+
+        foreach ($candidates as $candidate) {
+            if (isset($candidate['server']) && isset($candidate['server']['id'])) {
+                $commands[$candidate['server']['id']] = $candidate['server'];
+            }
+        }
+
+        return $commands;
+    }
+}

--- a/lib/Exec.php
+++ b/lib/Exec.php
@@ -1,0 +1,136 @@
+<?php
+
+class Exec
+{
+    public static function run(array $command, array $args, array $config): array
+    {
+        if (empty($command['template'])) {
+            throw new InvalidArgumentException('Command template is required.');
+        }
+
+        $tokens = self::tokenize($command['template']);
+        if (empty($tokens)) {
+            throw new InvalidArgumentException('Command template produced no executable tokens.');
+        }
+
+        $tokens = self::substituteTokens($tokens, $args);
+
+        $binary = $tokens[0];
+        $allowed = $config['whitelist'] ?? [];
+        self::assertAllowedBinary($binary, $allowed);
+        $resolvedBinary = self::resolveBinary($binary);
+
+        $commandList = array_merge([$resolvedBinary], array_slice($tokens, 1));
+
+        $descriptorSpec = [
+            0 => ['pipe', 'r'],
+            1 => ['pipe', 'w'],
+            2 => ['pipe', 'w'],
+        ];
+
+        $process = proc_open($commandList, $descriptorSpec, $pipes);
+        if (!is_resource($process)) {
+            throw new RuntimeException('Unable to start process for command: ' . $binary);
+        }
+
+        fclose($pipes[0]);
+        stream_set_blocking($pipes[1], true);
+        stream_set_blocking($pipes[2], true);
+        $stdout = stream_get_contents($pipes[1]);
+        $stderr = stream_get_contents($pipes[2]);
+        fclose($pipes[1]);
+        fclose($pipes[2]);
+
+        $exitCode = proc_close($process);
+
+        return [
+            'ok' => $exitCode === 0,
+            'code' => $exitCode,
+            'stdout' => $stdout,
+            'stderr' => $stderr,
+            'ts' => date(DATE_ATOM),
+        ];
+    }
+
+    private static function tokenize(string $template): array
+    {
+        $pattern = "/\"([^\"\\\\]*(?:\\\\.[^\"\\\\]*)*)\"|'([^'\\\\]*(?:\\\\.[^'\\\\]*)*)'|(\\S+)/";
+        preg_match_all($pattern, $template, $matches, PREG_SET_ORDER);
+        $tokens = [];
+        foreach ($matches as $match) {
+            if (!empty($match[1])) {
+                $tokens[] = stripcslashes($match[1]);
+            } elseif (!empty($match[2])) {
+                $tokens[] = stripcslashes($match[2]);
+            } elseif (!empty($match[3])) {
+                $tokens[] = $match[3];
+            }
+        }
+        return $tokens;
+    }
+
+    private static function substituteTokens(array $tokens, array $args): array
+    {
+        $processed = [];
+        foreach ($tokens as $token) {
+            $value = preg_replace_callback('/\$\{([A-Za-z0-9_]+)\}/', function ($matches) use ($args) {
+                $key = $matches[1];
+                if (!array_key_exists($key, $args)) {
+                    throw new InvalidArgumentException('Missing argument: ' . $key);
+                }
+                return self::sanitizeArg($args[$key]);
+            }, $token);
+            $processed[] = $value;
+        }
+        return $processed;
+    }
+
+    private static function sanitizeArg($value): string
+    {
+        if (is_bool($value)) {
+            $value = $value ? '1' : '0';
+        } elseif (is_int($value) || is_float($value)) {
+            $value = (string) $value;
+        } elseif ($value === null) {
+            $value = '';
+        } elseif (!is_string($value)) {
+            $value = json_encode($value);
+        }
+
+        $value = (string) $value;
+        if (preg_match('/[\x00-\x1F\x7F]/', $value)) {
+            throw new InvalidArgumentException('Argument contains control characters.');
+        }
+        if (preg_match('/[;&|`$<>]/', $value)) {
+            throw new InvalidArgumentException('Argument contains forbidden characters.');
+        }
+
+        return $value;
+    }
+
+    private static function assertAllowedBinary(string $binary, array $allowed): void
+    {
+        if ($binary === '') {
+            throw new InvalidArgumentException('Empty binary.');
+        }
+        if (strpos($binary, '/') !== false) {
+            throw new InvalidArgumentException('Binary paths are not allowed; use whitelist names only.');
+        }
+        $base = basename($binary);
+        if (!in_array($base, $allowed, true)) {
+            throw new RuntimeException('Binary not whitelisted: ' . $base);
+        }
+    }
+
+    private static function resolveBinary(string $binary): string
+    {
+        $paths = explode(PATH_SEPARATOR, getenv('PATH') ?: '');
+        foreach ($paths as $dir) {
+            $candidate = rtrim($dir, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR . $binary;
+            if (is_file($candidate) && is_executable($candidate)) {
+                return $candidate;
+            }
+        }
+        throw new RuntimeException('Binary not found in PATH: ' . $binary);
+    }
+}

--- a/public/css/custom.css
+++ b/public/css/custom.css
@@ -1,0 +1,21 @@
+/* public/css/custom.css */
+:root {
+  color-scheme: light;
+}
+
+body {
+  background: var(--surface-color, #f8fafc);
+}
+
+.component-card {
+  backdrop-filter: blur(6px);
+}
+
+.component-card[data-state="error"] {
+  border-color: rgba(220, 38, 38, 0.6);
+  box-shadow: 0 0 0 1px rgba(220, 38, 38, 0.15), 0 10px 30px -20px rgba(220, 38, 38, 0.6);
+}
+
+.component-card pre {
+  font-family: 'JetBrains Mono', 'Fira Code', 'SFMono-Regular', ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+}

--- a/public/index.php
+++ b/public/index.php
@@ -1,0 +1,49 @@
+<?php
+require_once __DIR__ . '/../lib/Core.php';
+
+$error = null;
+$config = [];
+try {
+    $config = Core::getConfig();
+} catch (Throwable $e) {
+    $error = $e->getMessage();
+}
+
+$embeddedConfig = $config ? json_encode($config, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES) : '{}';
+$fontStack = $config['globals']['theme']['font'] ?? 'Inter, system-ui, sans-serif';
+$primary = $config['globals']['theme']['palette']['primary'] ?? '#111827';
+$accent = $config['globals']['theme']['palette']['accent'] ?? '#10B981';
+$surface = $config['globals']['theme']['palette']['surface'] ?? '#F8FAFC';
+?>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>LocalUI</title>
+    <script src="https://cdn.tailwindcss.com?plugins=forms,typography"></script>
+    <link rel="stylesheet" href="/css/custom.css">
+    <style>
+        :root {
+            --primary-color: <?= htmlspecialchars($primary, ENT_QUOTES, 'UTF-8'); ?>;
+            --accent-color: <?= htmlspecialchars($accent, ENT_QUOTES, 'UTF-8'); ?>;
+            --surface-color: <?= htmlspecialchars($surface, ENT_QUOTES, 'UTF-8'); ?>;
+        }
+        body {
+            font-family: <?= htmlspecialchars($fontStack, ENT_QUOTES, 'UTF-8'); ?>;
+        }
+    </style>
+</head>
+<body class="bg-slate-100 min-h-screen">
+<?php if ($error): ?>
+    <div class="max-w-2xl mx-auto mt-12 bg-red-50 border border-red-200 text-red-800 rounded p-6">
+        <h1 class="text-xl font-semibold mb-2">Configuration Error</h1>
+        <p><?= htmlspecialchars($error, ENT_QUOTES, 'UTF-8'); ?></p>
+    </div>
+<?php else: ?>
+    <div id="app" class="min-h-screen"></div>
+    <script id="app-config" type="application/json"><?= $embeddedConfig; ?></script>
+    <script src="/js/app.js" defer></script>
+<?php endif; ?>
+</body>
+</html>

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -1,0 +1,488 @@
+(function () {
+  const configEl = document.getElementById('app-config');
+  const appRoot = document.getElementById('app');
+  if (!configEl || !appRoot) {
+    return;
+  }
+
+  let config;
+  try {
+    config = JSON.parse(configEl.textContent || '{}');
+  } catch (err) {
+    console.error('Failed to parse UI config', err);
+    return;
+  }
+
+  const state = {
+    config,
+    views: {},
+    polling: {},
+    results: {},
+  };
+
+  setupLayout(appRoot, config.globals || {});
+
+  (config.elements || []).forEach((element) => {
+    try {
+      renderElement(element);
+      hydrateLastResult(element.id);
+    } catch (err) {
+      console.error('Failed to render element', element, err);
+    }
+  });
+
+  window.addEventListener('beforeunload', () => {
+    Object.values(state.polling).forEach((intervalId) => clearInterval(intervalId));
+  });
+
+  function setupLayout(root, globals) {
+    root.className = '';
+    const layout = (globals.theme && globals.theme.layout) || 'grid';
+    const gap = (globals.theme && globals.theme.gap) || 8;
+    const margins = (globals.theme && globals.theme.margins) || 12;
+
+    if (layout === 'grid') {
+      root.classList.add('grid', 'grid-cols-1', 'md:grid-cols-12', 'auto-rows-min');
+    } else {
+      root.classList.add('flex', 'flex-col');
+    }
+    root.classList.add('min-h-screen', 'box-border');
+    root.style.padding = `${margins}px`;
+    root.style.gap = `${gap}px`;
+  }
+
+  function renderElement(element) {
+    const card = document.createElement('div');
+    card.dataset.elementId = element.id;
+    card.className = 'component-card bg-white/90 shadow-sm rounded-lg border border-slate-200 p-4 flex flex-col space-y-3 transition-all duration-150';
+    card.className += element.classes ? ` ${element.classes}` : '';
+    card.style.gridColumn = `span ${element.w || 12} / span ${element.w || 12}`;
+    card.style.gridRow = `span ${element.h || 1} / span ${element.h || 1}`;
+    if (element.bg) {
+      card.style.backgroundColor = element.bg;
+    }
+    if (element.color) {
+      card.style.color = element.color;
+    }
+    if (element.font) {
+      card.style.fontFamily = element.font;
+    }
+    if (element.tooltip) {
+      card.title = element.tooltip;
+    }
+
+    const header = document.createElement('div');
+    header.className = 'flex items-center justify-between';
+    const title = document.createElement('h2');
+    title.className = 'text-sm font-semibold tracking-wide text-slate-700 uppercase';
+    title.textContent = element.label || element.id;
+    header.appendChild(title);
+    card.appendChild(header);
+
+    const body = document.createElement('div');
+    body.className = 'flex flex-col gap-3 text-sm text-slate-700';
+    card.appendChild(body);
+
+    const view = attachResultView(card);
+    state.views[element.id] = view;
+
+    switch (element.type) {
+      case 'button':
+        renderButton(element, body);
+        break;
+      case 'toggle':
+        renderToggle(element, body);
+        break;
+      case 'stepper':
+        renderStepper(element, body);
+        break;
+      case 'input':
+        renderInput(element, body);
+        break;
+      case 'output':
+        renderOutput(element, body);
+        break;
+      default:
+        body.textContent = `Unsupported element type: ${element.type}`;
+    }
+
+    appRoot.appendChild(card);
+  }
+
+  function attachResultView(card) {
+    const wrapper = document.createElement('div');
+    wrapper.className = 'space-y-2 text-xs text-slate-600 hidden';
+
+    const meta = document.createElement('div');
+    meta.className = 'text-xs text-slate-500';
+    wrapper.appendChild(meta);
+
+    const stdout = document.createElement('pre');
+    stdout.className = 'bg-slate-900/95 text-slate-100 p-3 rounded-md overflow-auto max-h-64 whitespace-pre-wrap break-words text-xs';
+    wrapper.appendChild(stdout);
+
+    const stderr = document.createElement('pre');
+    stderr.className = 'bg-red-900/90 text-red-100 p-3 rounded-md overflow-auto max-h-48 whitespace-pre-wrap break-words text-xs hidden';
+    wrapper.appendChild(stderr);
+
+    card.appendChild(wrapper);
+
+    return { wrapper, meta, stdout, stderr };
+  }
+
+  function renderButton(element, container) {
+    const button = createButton(element.label || 'Run', 'primary');
+    container.appendChild(button);
+
+    button.addEventListener('click', async () => {
+      if (element.command && element.command.server) {
+        await executeServerCommand(element.id, element.command.server, button);
+      }
+      if (element.command && element.command.client && element.command.client.script) {
+        runClientScript(element, element.command.client.script);
+      }
+    });
+  }
+
+  function renderToggle(element, container) {
+    const row = document.createElement('div');
+    row.className = 'flex items-center justify-between gap-3';
+
+    const checkbox = document.createElement('input');
+    checkbox.type = 'checkbox';
+    checkbox.checked = !!element.initial;
+    checkbox.className = 'h-5 w-5 text-[var(--accent-color)] focus:ring-[var(--accent-color)] border-slate-300 rounded';
+
+    const status = document.createElement('span');
+    status.className = 'text-sm font-medium text-slate-600';
+    status.textContent = checkbox.checked ? 'On' : 'Off';
+
+    row.appendChild(checkbox);
+    row.appendChild(status);
+    container.appendChild(row);
+
+    checkbox.addEventListener('change', async () => {
+      status.textContent = checkbox.checked ? 'On' : 'Off';
+      const command = checkbox.checked ? element.onCommand?.server : element.offCommand?.server;
+      if (!command) {
+        return;
+      }
+      try {
+        checkbox.disabled = true;
+        await executeServerCommand(element.id, command, null, { value: checkbox.checked });
+      } catch (err) {
+        checkbox.checked = !checkbox.checked;
+        status.textContent = checkbox.checked ? 'On' : 'Off';
+        showError(element.id, err.message);
+      } finally {
+        checkbox.disabled = false;
+      }
+    });
+  }
+
+  function renderStepper(element, container) {
+    const wrap = document.createElement('div');
+    wrap.className = 'flex items-center gap-2';
+
+    const minus = createButton('−', 'secondary');
+    minus.classList.add('w-10');
+    const plus = createButton('+', 'secondary');
+    plus.classList.add('w-10');
+
+    const input = document.createElement('input');
+    input.type = 'number';
+    input.className = 'w-24 rounded-md border border-slate-300 px-3 py-2 text-sm focus:border-[var(--accent-color)] focus:ring-[var(--accent-color)]';
+    input.min = element.min;
+    input.max = element.max;
+    input.step = element.step;
+    input.value = element.value;
+
+    const apply = createButton('Apply', 'primary');
+
+    wrap.appendChild(minus);
+    wrap.appendChild(input);
+    wrap.appendChild(plus);
+    wrap.appendChild(apply);
+    container.appendChild(wrap);
+
+    const clamp = (value) => {
+      const min = Number(element.min);
+      const max = Number(element.max);
+      const step = Number(element.step) || 1;
+      let next = Number.isFinite(value) ? value : min;
+      if (next < min) next = min;
+      if (next > max) next = max;
+      next = Math.round(next / step) * step;
+      if (next < min) next = min;
+      if (next > max) next = max;
+      return next;
+    };
+
+    const triggerCommand = async (value) => {
+      if (!element.command || !element.command.server) {
+        return;
+      }
+      await executeServerCommand(element.id, element.command.server, apply, { value });
+    };
+
+    minus.addEventListener('click', () => {
+      const current = Number(input.value);
+      const next = clamp(current - (Number(element.step) || 1));
+      input.value = next;
+      triggerCommand(next).catch((err) => showError(element.id, err.message));
+    });
+
+    plus.addEventListener('click', () => {
+      const current = Number(input.value);
+      const next = clamp(current + (Number(element.step) || 1));
+      input.value = next;
+      triggerCommand(next).catch((err) => showError(element.id, err.message));
+    });
+
+    apply.addEventListener('click', () => {
+      const next = clamp(Number(input.value));
+      input.value = next;
+      triggerCommand(next).catch((err) => showError(element.id, err.message));
+    });
+
+    input.addEventListener('change', () => {
+      const next = clamp(Number(input.value));
+      input.value = next;
+    });
+  }
+
+  function renderInput(element, container) {
+    const wrap = document.createElement('div');
+    wrap.className = 'flex flex-col gap-2';
+
+    let inputControl;
+    let valueGetter;
+
+    switch (element.inputType) {
+      case 'int':
+        inputControl = document.createElement('input');
+        inputControl.type = 'number';
+        inputControl.className = 'rounded-md border border-slate-300 px-3 py-2 text-sm focus:border-[var(--accent-color)] focus:ring-[var(--accent-color)]';
+        valueGetter = () => Number(inputControl.value || 0);
+        break;
+      case 'bool':
+        inputControl = document.createElement('select');
+        inputControl.className = 'rounded-md border border-slate-300 px-3 py-2 text-sm focus:border-[var(--accent-color)] focus:ring-[var(--accent-color)]';
+        const optFalse = document.createElement('option');
+        optFalse.value = 'false';
+        optFalse.textContent = 'False';
+        const optTrue = document.createElement('option');
+        optTrue.value = 'true';
+        optTrue.textContent = 'True';
+        inputControl.appendChild(optFalse);
+        inputControl.appendChild(optTrue);
+        valueGetter = () => inputControl.value === 'true';
+        break;
+      default:
+        inputControl = document.createElement('input');
+        inputControl.type = 'text';
+        inputControl.placeholder = element.placeholder || '';
+        inputControl.className = 'rounded-md border border-slate-300 px-3 py-2 text-sm focus:border-[var(--accent-color)] focus:ring-[var(--accent-color)]';
+        valueGetter = () => inputControl.value;
+    }
+
+    wrap.appendChild(inputControl);
+
+    if (element.apply && element.apply.command && element.apply.command.server) {
+      const button = createButton(element.apply.label || 'Apply', 'primary');
+      button.addEventListener('click', () => {
+        const raw = valueGetter();
+        const args = { value: raw };
+        executeServerCommand(element.id, element.apply.command.server, button, args).catch((err) => {
+          showError(element.id, err.message);
+        });
+      });
+      wrap.appendChild(button);
+    }
+
+    container.appendChild(wrap);
+  }
+
+  function renderOutput(element, container) {
+    const controls = document.createElement('div');
+    controls.className = 'flex items-center gap-2';
+
+    if (element.mode === 'manual' && element.command && element.command.server) {
+      const button = createButton(element.onDemandButtonLabel || 'Refresh', 'primary');
+      controls.appendChild(button);
+      button.addEventListener('click', () => {
+        executeServerCommand(element.id, element.command.server, button).catch((err) => {
+          showError(element.id, err.message);
+        });
+      });
+    }
+
+    container.appendChild(controls);
+
+    if (element.mode === 'poll' && element.command && element.command.server) {
+      const interval = Math.max(500, Number(element.intervalMs) || 5000);
+      const run = () => {
+        executeServerCommand(element.id, element.command.server).catch((err) => {
+          showError(element.id, err.message);
+        });
+      };
+      run();
+      if (state.polling[element.id]) {
+        clearInterval(state.polling[element.id]);
+      }
+      state.polling[element.id] = setInterval(run, interval);
+    }
+  }
+
+  async function executeServerCommand(elementId, command, buttonEl, extraArgs) {
+    if (!command || !command.id) {
+      throw new Error('Missing command configuration');
+    }
+    if (buttonEl) {
+      setLoading(buttonEl, true);
+    }
+    const payload = {
+      id: elementId,
+      commandId: command.id,
+      args: extraArgs || {},
+    };
+
+    try {
+      const response = await fetch('/api/run', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload),
+      });
+      const data = await response.json().catch(() => null);
+      if (!response.ok || !data) {
+        const message = (data && data.error) ? data.error : `Request failed with status ${response.status}`;
+        throw new Error(message);
+      }
+      applyResult(elementId, data);
+      return data;
+    } finally {
+      if (buttonEl) {
+        setLoading(buttonEl, false);
+      }
+    }
+  }
+
+  function applyResult(elementId, payload) {
+    const view = state.views[elementId];
+    if (!view) {
+      return;
+    }
+    const result = payload.result || payload;
+    const ok = !!payload.ok;
+    state.results[elementId] = result;
+
+    view.wrapper.classList.remove('hidden');
+    view.meta.textContent = `Exit ${result.code} · ${formatTimestamp(result.ts)}`;
+
+    if (result.stdout) {
+      view.stdout.textContent = result.stdout;
+      view.stdout.classList.remove('hidden');
+    } else {
+      view.stdout.textContent = '';
+      view.stdout.classList.add('hidden');
+    }
+
+    if (result.stderr) {
+      view.stderr.textContent = result.stderr;
+      view.stderr.classList.remove('hidden');
+    } else {
+      view.stderr.textContent = '';
+      view.stderr.classList.add('hidden');
+    }
+
+    const card = getCard(elementId);
+    if (card) {
+      card.dataset.state = ok ? 'ok' : 'error';
+      card.classList.toggle('ring-2', !ok);
+      card.classList.toggle('ring-red-400', !ok);
+      if (ok) {
+        card.classList.remove('ring-2', 'ring-red-400');
+      }
+    }
+  }
+
+  function showError(elementId, message) {
+    const fallback = {
+      ok: false,
+      code: 'ERR',
+      stdout: '',
+      stderr: message,
+      ts: new Date().toISOString(),
+    };
+    applyResult(elementId, { ok: false, result: fallback });
+  }
+
+  function setLoading(button, loading) {
+    if (!button) return;
+    if (loading) {
+      if (!button.dataset.originalLabel) {
+        button.dataset.originalLabel = button.textContent;
+      }
+      button.textContent = 'Running…';
+      button.disabled = true;
+    } else {
+      if (button.dataset.originalLabel) {
+        button.textContent = button.dataset.originalLabel;
+        delete button.dataset.originalLabel;
+      }
+      button.disabled = false;
+    }
+  }
+
+  function createButton(label, variant) {
+    const button = document.createElement('button');
+    button.type = 'button';
+    const baseClasses = 'inline-flex items-center justify-center px-3 py-2 rounded-md text-sm font-medium focus:outline-none focus:ring-2 focus:ring-offset-2 transition disabled:opacity-60 disabled:cursor-not-allowed';
+    if (variant === 'secondary') {
+      button.className = `${baseClasses} border border-slate-300 text-slate-700 hover:bg-slate-100 focus:ring-slate-400`;
+    } else {
+      button.className = `${baseClasses} text-white bg-slate-900 hover:bg-slate-800 focus:ring-slate-500`;
+      button.style.backgroundColor = 'var(--primary-color)';
+      button.style.borderColor = 'var(--primary-color)';
+    }
+    button.textContent = label;
+    return button;
+  }
+
+  function getCard(elementId) {
+    return document.querySelector(`[data-element-id="${elementId}"]`);
+  }
+
+  function formatTimestamp(ts) {
+    try {
+      return new Date(ts).toLocaleString();
+    } catch (err) {
+      return ts;
+    }
+  }
+
+  function runClientScript(element, script) {
+    try {
+      // eslint-disable-next-line no-new-func
+      const fn = new Function('element', 'state', script);
+      fn(element, state);
+    } catch (err) {
+      showError(element.id, err.message);
+    }
+  }
+
+  async function hydrateLastResult(elementId) {
+    try {
+      const response = await fetch(`/api/read?id=${encodeURIComponent(elementId)}`);
+      if (!response.ok) {
+        return;
+      }
+      const data = await response.json();
+      if (data) {
+        applyResult(elementId, data);
+      }
+    } catch (err) {
+      console.warn('Unable to hydrate result', elementId, err);
+    }
+  }
+})();


### PR DESCRIPTION
## Summary
- implement PHP config loader, safe execution wrapper, and API endpoints for running whitelisted commands
- render Tailwind-based frontend that generates controls from JSON and polls output elements
- document configuration schema, provide sample UI JSON, and add styling assets

## Testing
- php -l public/index.php
- php -l api/index.php
- php -l lib/Core.php
- php -l lib/Defaults.php
- php -l lib/Elements.php
- php -l lib/Exec.php

------
https://chatgpt.com/codex/tasks/task_e_68cbe3e52074832d9d0a7a795fcfc1d6