### PR TITLE
Add grouped layout support with relative positioning

### DIFF
--- a/config/ui.sample.json
+++ b/config/ui.sample.json
@@ -15,103 +15,176 @@
   },
   "elements": [
     {
-      "id": "uptimeInfo",
-      "type": "button",
-      "label": "Check uptime",
-      "tooltip": "Shows the uptime as a toast notification",
-      "command": { "server": { "id": "uptime", "template": "uptime" } },
-      "presentation": "notification",
-      "timeoutMs": 4000
+      "id": "systemControls",
+      "type": "group",
+      "label": "System controls",
+      "w": 6,
+      "h": 4,
+      "x": 0,
+      "y": 0,
+      "columns": 6,
+      "gap": 12,
+      "border": true,
+      "background": "rgba(15, 23, 42, 0.45)",
+      "elements": [
+        {
+          "id": "uptimeInfo",
+          "type": "button",
+          "label": "Check uptime",
+          "tooltip": "Shows the uptime as a toast notification",
+          "command": { "server": { "id": "uptime", "template": "uptime" } },
+          "presentation": "notification",
+          "timeoutMs": 4000,
+          "w": 3,
+          "h": 2,
+          "x": 0,
+          "y": 0
+        },
+        {
+          "id": "mute",
+          "type": "toggle",
+          "label": "Mute",
+          "onCommand": { "server": { "id": "mute", "template": "pactl set-sink-mute @DEFAULT_SINK@ 1" } },
+          "offCommand": { "server": { "id": "unmute", "template": "pactl set-sink-mute @DEFAULT_SINK@ 0" } },
+          "initial": false,
+          "presentation": "inline",
+          "timeoutMs": 0,
+          "w": 3,
+          "h": 2,
+          "x": 3,
+          "y": 0
+        },
+        {
+          "id": "stepVol",
+          "type": "stepper",
+          "label": "Volume",
+          "min": 0,
+          "max": 150,
+          "step": 5,
+          "value": 50,
+          "command": { "server": { "id": "setVol", "template": "pactl set-sink-volume @DEFAULT_SINK@ ${value}%" } },
+          "presentation": "popover",
+          "timeoutMs": 5000,
+          "w": 6,
+          "h": 2,
+          "x": 0,
+          "y": 2
+        }
+      ]
     },
     {
-      "id": "mute",
-      "type": "toggle",
-      "label": "Mute",
-      "onCommand": { "server": { "id": "mute", "template": "pactl set-sink-mute @DEFAULT_SINK@ 1" } },
-      "offCommand": { "server": { "id": "unmute", "template": "pactl set-sink-mute @DEFAULT_SINK@ 0" } },
-      "initial": false,
-      "presentation": "inline",
-      "timeoutMs": 0
+      "id": "inputPane",
+      "type": "group",
+      "label": "File tools",
+      "w": 6,
+      "h": 4,
+      "x": 6,
+      "y": 0,
+      "columns": 6,
+      "gap": 12,
+      "border": "1px solid rgba(148, 163, 184, 0.35)",
+      "background": "rgba(15, 23, 42, 0.32)",
+      "elements": [
+        {
+          "id": "inpFile",
+          "type": "input",
+          "label": "File path",
+          "inputType": "string",
+          "apply": {
+            "label": "Preview",
+            "command": { "server": { "id": "catFile", "template": "cat ${value}" } }
+          },
+          "presentation": "modal",
+          "timeoutMs": 8000,
+          "w": 6,
+          "h": 3,
+          "x": 0,
+          "y": 0
+        }
+      ]
     },
     {
-      "id": "stepVol",
-      "type": "stepper",
-      "label": "Volume",
-      "min": 0,
-      "max": 150,
-      "step": 5,
-      "value": 50,
-      "command": { "server": { "id": "setVol", "template": "pactl set-sink-volume @DEFAULT_SINK@ ${value}%" } },
-      "presentation": "popover",
-      "timeoutMs": 5000
-    },
-    {
-      "id": "inpFile",
-      "type": "input",
-      "label": "File path",
-      "inputType": "string",
-      "apply": {
-        "label": "Preview",
-        "command": { "server": { "id": "catFile", "template": "cat ${value}" } }
-      },
-      "presentation": "modal",
-      "timeoutMs": 8000
-    },
-    {
-      "id": "envOut",
-      "type": "output",
-      "label": "Environment",
-      "command": { "server": { "id": "printEnv", "template": "env" } },
-      "mode": "poll",
-      "intervalMs": 5000,
-      "presentation": "inline",
-      "timeoutMs": 0,
+      "id": "systemOutputs",
+      "type": "group",
+      "label": "System information",
       "w": 12,
-      "h": 4
-    },
-    {
-      "id": "fastfetch",
-      "type": "output",
-      "label": "Fastfetch",
-      "command": { "server": { "id": "fastfetch", "template": "fastfetch --logo none" } },
-      "mode": "manual",
-      "onDemandButtonLabel": "Refresh",
-      "presentation": "modal",
-      "timeoutMs": 9000,
-      "w": 12,
-      "h": 3
-    },
-    {
-      "id": "diskUsage",
-      "type": "output",
-      "label": "Disk usage",
-      "command": { "server": { "id": "diskUsage", "template": "df -h /" } },
-      "mode": "manual",
-      "onDemandButtonLabel": "Check disk",
-      "presentation": "popover",
-      "timeoutMs": 6000
-    },
-    {
-      "id": "hostname",
-      "type": "output",
-      "label": "Hostname",
-      "command": { "server": { "id": "hostname", "template": "hostname" } },
-      "mode": "manual",
-      "onDemandButtonLabel": "Read host",
-      "presentation": "tooltip",
-      "timeoutMs": 3000
-    },
-    {
-      "id": "journalTail",
-      "type": "output",
-      "label": "Latest system log entries",
-      "command": { "server": { "id": "tailSyslog", "template": "tail -n 20 /var/log/syslog" } },
-      "mode": "poll",
-      "intervalMs": 15000,
-      "presentation": "notification",
-      "timeoutMs": 7000,
-      "w": 12,
-      "h": 2
+      "h": 10,
+      "x": 0,
+      "y": 4,
+      "border": true,
+      "gap": 16,
+      "elements": [
+        {
+          "id": "envOut",
+          "type": "output",
+          "label": "Environment",
+          "command": { "server": { "id": "printEnv", "template": "env" } },
+          "mode": "poll",
+          "intervalMs": 5000,
+          "presentation": "inline",
+          "timeoutMs": 0,
+          "w": 12,
+          "h": 4,
+          "x": 0,
+          "y": 0
+        },
+        {
+          "id": "fastfetch",
+          "type": "output",
+          "label": "Fastfetch",
+          "command": { "server": { "id": "fastfetch", "template": "fastfetch --logo none" } },
+          "mode": "manual",
+          "onDemandButtonLabel": "Refresh",
+          "presentation": "modal",
+          "timeoutMs": 9000,
+          "w": 6,
+          "h": 3,
+          "x": 0,
+          "y": 4
+        },
+        {
+          "id": "diskUsage",
+          "type": "output",
+          "label": "Disk usage",
+          "command": { "server": { "id": "diskUsage", "template": "df -h /" } },
+          "mode": "manual",
+          "onDemandButtonLabel": "Check disk",
+          "presentation": "popover",
+          "timeoutMs": 6000,
+          "w": 6,
+          "h": 2,
+          "x": 6,
+          "y": 4
+        },
+        {
+          "id": "hostname",
+          "type": "output",
+          "label": "Hostname",
+          "command": { "server": { "id": "hostname", "template": "hostname" } },
+          "mode": "manual",
+          "onDemandButtonLabel": "Read host",
+          "presentation": "tooltip",
+          "timeoutMs": 3000,
+          "w": 6,
+          "h": 1,
+          "x": 6,
+          "y": 7
+        },
+        {
+          "id": "journalTail",
+          "type": "output",
+          "label": "Latest system log entries",
+          "command": { "server": { "id": "tailSyslog", "template": "tail -n 20 /var/log/syslog" } },
+          "mode": "poll",
+          "intervalMs": 15000,
+          "presentation": "notification",
+          "timeoutMs": 7000,
+          "w": 12,
+          "h": 2,
+          "x": 0,
+          "y": 8
+        }
+      ]
     }
   ],
   "whitelist": ["cat", "df", "env", "fastfetch", "hostname", "pactl", "tail", "uptime"]

--- a/public/css/custom.css
+++ b/public/css/custom.css
@@ -34,6 +34,40 @@ body {
   transition: transform 0.2s ease, box-shadow 0.25s ease, border-color 0.2s ease;
 }
 
+.component-group {
+  border-radius: 1.35rem;
+  padding: 1.35rem;
+  background: transparent;
+  border: 1px solid transparent;
+  box-shadow: none;
+  backdrop-filter: none;
+  transition: border-color 0.2s ease, box-shadow 0.25s ease, background 0.25s ease;
+}
+
+.component-group-pane {
+  border-color: var(--surface-border);
+  background: rgba(15, 23, 42, 0.58);
+  box-shadow: var(--shadow-strong);
+  backdrop-filter: blur(14px);
+}
+
+.component-group-header {
+  font-size: 0.75rem;
+  font-weight: 600;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--text-secondary);
+  margin-bottom: 0.75rem;
+}
+
+.component-group-body {
+  min-height: 0;
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
 .component-card:hover {
   transform: translateY(-2px);
   box-shadow: var(--shadow-hover);


### PR DESCRIPTION
## Summary
- add backend normalization for group containers with nested elements, per-item coordinates, and layout hints
- render group panes on the frontend with relative placement, optional borders/backgrounds, and polling activation
- style grouped panes and update the sample configuration to demonstrate nested layouts and positioning

## Testing
- php -l lib/Elements.php

------
https://chatgpt.com/codex/tasks/task_e_68cbfa1b01c8832d893145a8bb7ff092