### PR TITLE
Prevent interactive actions from running on refresh

### DIFF
--- a/public/js/app.js
+++ b/public/js/app.js
@@ -1016,20 +1016,31 @@
     }
   }
 
+  function shouldDisplayResult(element, hadPending) {
+    if (!element) {
+      return hadPending;
+    }
+    if (element.type === 'output' && element.mode === 'poll') {
+      return true;
+    }
+    return hadPending;
+  }
+
   function applyResult(elementId, payload) {
+    const element = elementIndex.get(elementId);
     const view = views.get(elementId);
-    if (!view) {
-      consumeUserAction(elementId);
-      return;
-    }
-    if (!payload || !payload.result) {
-      consumeUserAction(elementId);
-      return;
-    }
-    view.showResult(payload);
     const hadPending = consumeUserAction(elementId);
+
+    if (!view || !payload || !payload.result) {
+      return;
+    }
+
+    if (!shouldDisplayResult(element, hadPending)) {
+      return;
+    }
+
+    view.showResult(payload);
     if (hadPending && payload.result.ok === false) {
-      const element = elementIndex.get(elementId);
       playElementSound(element, 'error');
     }
   }
@@ -1043,14 +1054,16 @@
   }
 
   function showError(elementId, message) {
+    const element = elementIndex.get(elementId);
     const view = views.get(elementId);
-    if (!view) {
-      consumeUserAction(elementId);
+    const hadPending = consumeUserAction(elementId);
+
+    if (!view || !shouldDisplayResult(element, hadPending)) {
       return;
     }
+
     view.showError(message);
-    if (consumeUserAction(elementId)) {
-      const element = elementIndex.get(elementId);
+    if (hadPending) {
       playElementSound(element, 'error');
     }
   }


### PR DESCRIPTION
## Summary
- add a guard that only displays stored results when the element polled or the user explicitly triggered it
- ensure hydration no longer replays actions for interactive elements during reloads
- align error handling with the new display guard so passive elements stay quiet on load

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68cc2caacbc4832da89c3ea21ba642ae