### PR TITLE
Add additional sample UI configurations with navigation

### DIFF
--- a/config/ui.alt.json
+++ b/config/ui.alt.json
@@ -25,17 +25,77 @@
       "type": "navbar",
       "label": "Alternate UI",
       "side": "top",
+      "defaults": { "presentation": "notification", "timeoutMs": 3200 },
       "elements": [
         {
-          "id": "altBack",
+          "id": "navAltMain",
           "type": "button",
-          "label": "Return to default",
+          "label": "Main layout",
           "command": {
             "client": {
               "loadConfig": {
                 "useDefault": true,
                 "label": "Default interface",
                 "loadingMessage": "Restoring default controls…"
+              }
+            }
+          }
+        },
+        {
+          "id": "navAltAlt",
+          "type": "button",
+          "label": "Alternate layout",
+          "tooltip": "Reload this stacked layout",
+          "bg": "rgba(236, 72, 153, 0.18)",
+          "color": "#EC4899",
+          "command": {
+            "client": {
+              "loadConfig": {
+                "name": "ui.alt",
+                "label": "Alternate interface",
+                "loadingMessage": "Loading alternate interface…"
+              }
+            }
+          }
+        },
+        {
+          "id": "navAltOps",
+          "type": "button",
+          "label": "Ops board",
+          "command": {
+            "client": {
+              "loadConfig": {
+                "name": "ui.ops",
+                "label": "Operations board",
+                "loadingMessage": "Opening operations board…"
+              }
+            }
+          }
+        },
+        {
+          "id": "navAltDiagnostics",
+          "type": "button",
+          "label": "Diagnostics",
+          "command": {
+            "client": {
+              "loadConfig": {
+                "name": "ui.diagnostics",
+                "label": "Diagnostics interface",
+                "loadingMessage": "Loading diagnostics tools…"
+              }
+            }
+          }
+        },
+        {
+          "id": "navAltMedia",
+          "type": "button",
+          "label": "Media deck",
+          "command": {
+            "client": {
+              "loadConfig": {
+                "name": "ui.media",
+                "label": "Media control deck",
+                "loadingMessage": "Loading media controls…"
               }
             }
           }
@@ -59,7 +119,8 @@
           "command": {
             "server": { "id": "fastfetch", "template": "fastfetch --logo none" }
           },
-          "onDemandButtonLabel": "Run fastfetch"
+          "onDemandButtonLabel": "Run fastfetch",
+          "w": 1
         },
         {
           "id": "altEnv",
@@ -70,7 +131,8 @@
           "command": {
             "server": { "id": "printEnv", "template": "env" }
           },
-          "onDemandButtonLabel": "Show env"
+          "onDemandButtonLabel": "Show env",
+          "w": 1
         },
         {
           "id": "altVolume",
@@ -82,7 +144,8 @@
           "value": 75,
           "command": {
             "server": { "id": "setVol", "template": "pactl set-sink-volume @DEFAULT_SINK@ ${value}%" }
-          }
+          },
+          "w": 1
         },
         {
           "id": "altMute",
@@ -94,7 +157,8 @@
           },
           "offCommand": {
             "server": { "id": "unmute", "template": "pactl set-sink-mute @DEFAULT_SINK@ 0" }
-          }
+          },
+          "w": 1
         }
       ]
     }

--- a/config/ui.diagnostics.json
+++ b/config/ui.diagnostics.json
@@ -1,0 +1,301 @@
+{
+  "globals": {
+    "theme": {
+      "palette": {
+        "primary": "#111827",
+        "accent": "#38BDF8",
+        "surface": "#0F172A",
+        "muted": "#64748B"
+      },
+      "font": "'Source Code Pro', 'JetBrains Mono', 'Fira Code', ui-monospace, 'SFMono-Regular', Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace",
+      "margins": 18,
+      "gap": 10,
+      "layout": "grid"
+    },
+    "defaults": { "w": 4, "h": 2, "classes": "" }
+  },
+  "elements": [
+    {
+      "id": "diagNavbar",
+      "type": "navbar",
+      "label": "Diagnostics center",
+      "side": "top",
+      "gap": 10,
+      "defaults": { "presentation": "notification", "timeoutMs": 3200 },
+      "elements": [
+        {
+          "id": "navDiagMain",
+          "type": "button",
+          "label": "Main layout",
+          "command": {
+            "client": {
+              "loadConfig": {
+                "useDefault": true,
+                "label": "Primary interface",
+                "loadingMessage": "Loading main interface…"
+              }
+            }
+          }
+        },
+        {
+          "id": "navDiagAlt",
+          "type": "button",
+          "label": "Alternate layout",
+          "command": {
+            "client": {
+              "loadConfig": {
+                "name": "ui.alt",
+                "label": "Alternate interface",
+                "loadingMessage": "Loading alternate interface…"
+              }
+            }
+          }
+        },
+        {
+          "id": "navDiagOps",
+          "type": "button",
+          "label": "Ops board",
+          "command": {
+            "client": {
+              "loadConfig": {
+                "name": "ui.ops",
+                "label": "Operations board",
+                "loadingMessage": "Opening operations board…"
+              }
+            }
+          }
+        },
+        {
+          "id": "navDiagDiag",
+          "type": "button",
+          "label": "Diagnostics",
+          "tooltip": "Reload diagnostics view",
+          "bg": "rgba(56, 189, 248, 0.18)",
+          "color": "#38BDF8",
+          "command": {
+            "client": {
+              "loadConfig": {
+                "name": "ui.diagnostics",
+                "label": "Diagnostics interface",
+                "loadingMessage": "Loading diagnostics tools…"
+              }
+            }
+          }
+        },
+        {
+          "id": "navDiagMedia",
+          "type": "button",
+          "label": "Media deck",
+          "command": {
+            "client": {
+              "loadConfig": {
+                "name": "ui.media",
+                "label": "Media control deck",
+                "loadingMessage": "Loading media controls…"
+              }
+            }
+          }
+        }
+      ]
+    },
+    {
+      "id": "diagChecks",
+      "type": "group",
+      "label": "Health checks",
+      "w": 12,
+      "h": 6,
+      "columns": 3,
+      "gap": 10,
+      "border": true,
+      "background": "rgba(15, 23, 42, 0.45)",
+      "elements": [
+        {
+          "id": "diagCpuDetail",
+          "type": "button",
+          "label": "CPU details",
+          "tooltip": "Inspect CPU characteristics",
+          "command": { "server": { "id": "diagCpuDetail", "template": "lscpu | head -n 15" } },
+          "presentation": "modal",
+          "timeoutMs": 7000,
+          "w": 1
+        },
+        {
+          "id": "diagMemoryUsage",
+          "type": "button",
+          "label": "Memory usage",
+          "command": { "server": { "id": "diagMemoryUsage", "template": "free -h" } },
+          "presentation": "notification",
+          "timeoutMs": 4000,
+          "w": 1
+        },
+        {
+          "id": "diagDiskUsage",
+          "type": "button",
+          "label": "Disk usage",
+          "command": { "server": { "id": "diagDiskUsage", "template": "df -h" } },
+          "presentation": "notification",
+          "timeoutMs": 4000,
+          "w": 1
+        },
+        {
+          "id": "diagSocketSummary",
+          "type": "button",
+          "label": "Socket summary",
+          "command": { "server": { "id": "diagSocketSummary", "template": "ss -s" } },
+          "presentation": "notification",
+          "timeoutMs": 5000,
+          "w": 1
+        },
+        {
+          "id": "diagTopProcesses",
+          "type": "button",
+          "label": "CPU processes",
+          "command": {
+            "server": {
+              "id": "diagTopProcesses",
+              "template": "ps aux --sort=-%cpu | head -n 8"
+            }
+          },
+          "presentation": "modal",
+          "timeoutMs": 7000,
+          "w": 1
+        },
+        {
+          "id": "diagUptime",
+          "type": "button",
+          "label": "System uptime",
+          "command": { "server": { "id": "diagUptime", "template": "uptime" } },
+          "presentation": "tooltip",
+          "timeoutMs": 3500,
+          "w": 1
+        }
+      ]
+    },
+    {
+      "id": "diagSnapshots",
+      "type": "group",
+      "label": "Snapshots",
+      "w": 12,
+      "h": 6,
+      "columns": 3,
+      "gap": 10,
+      "border": true,
+      "background": "rgba(15, 23, 42, 0.35)",
+      "elements": [
+        {
+          "id": "diagLoadAverage",
+          "type": "output",
+          "label": "Load average",
+          "command": { "server": { "id": "diagLoadAverage", "template": "cat /proc/loadavg" } },
+          "mode": "poll",
+          "intervalMs": 8000,
+          "presentation": "inline",
+          "timeoutMs": 0,
+          "h": 3,
+          "w": 1
+        },
+        {
+          "id": "diagMemorySnapshot",
+          "type": "output",
+          "label": "Memory snapshot",
+          "command": {
+            "server": {
+              "id": "diagMemorySnapshot",
+              "template": "cat /proc/meminfo | head -n 8"
+            }
+          },
+          "mode": "manual",
+          "onDemandButtonLabel": "Read meminfo",
+          "presentation": "popover",
+          "timeoutMs": 6000,
+          "h": 3,
+          "w": 1
+        },
+        {
+          "id": "diagDiskLayout",
+          "type": "output",
+          "label": "Block devices",
+          "command": { "server": { "id": "diagDiskLayout", "template": "lsblk" } },
+          "mode": "manual",
+          "onDemandButtonLabel": "Show devices",
+          "presentation": "modal",
+          "timeoutMs": 7000,
+          "h": 3,
+          "w": 1
+        }
+      ]
+    },
+    {
+      "id": "diagLogTools",
+      "type": "group",
+      "label": "Log tools",
+      "w": 12,
+      "h": 5,
+      "columns": 3,
+      "gap": 10,
+      "border": true,
+      "background": "rgba(15, 23, 42, 0.3)",
+      "elements": [
+        {
+          "id": "diagSearchLogs",
+          "type": "input",
+          "label": "Search logs",
+          "inputType": "string",
+          "apply": {
+            "label": "Search",
+            "command": {
+              "server": {
+                "id": "diagSearchLogs",
+                "template": "grep -i ${value} /var/log/syslog | tail -n 20"
+              }
+            }
+          },
+          "presentation": "modal",
+          "timeoutMs": 8000,
+          "w": 1,
+          "h": 3
+        },
+        {
+          "id": "diagVerboseToggle",
+          "type": "toggle",
+          "label": "Verbose mode",
+          "onCommand": { "server": { "id": "diagVerboseOn", "template": "printf 'Verbose diagnostics enabled\\n'" } },
+          "offCommand": { "server": { "id": "diagVerboseOff", "template": "printf 'Verbose diagnostics disabled\\n'" } },
+          "initial": false,
+          "presentation": "notification",
+          "timeoutMs": 3200,
+          "w": 1,
+          "h": 3
+        },
+        {
+          "id": "diagSampleWindow",
+          "type": "stepper",
+          "label": "Sample window (s)",
+          "min": 5,
+          "max": 60,
+          "step": 5,
+          "value": 15,
+          "command": { "server": { "id": "diagSampleWindow", "template": "printf 'Sampling window set to %s seconds\\n' ${value}" } },
+          "presentation": "tooltip",
+          "timeoutMs": 4000,
+          "w": 1,
+          "h": 3
+        }
+      ]
+    }
+  ],
+  "whitelist": [
+    "cat",
+    "df",
+    "free",
+    "grep",
+    "head",
+    "lscpu",
+    "lsblk",
+    "printf",
+    "ps",
+    "ss",
+    "tail",
+    "uptime"
+  ]
+}

--- a/config/ui.media.json
+++ b/config/ui.media.json
@@ -1,0 +1,267 @@
+{
+  "globals": {
+    "theme": {
+      "palette": {
+        "primary": "#1E1B4B",
+        "accent": "#F472B6",
+        "surface": "#0F172A",
+        "muted": "#94A3B8"
+      },
+      "font": "'Space Mono', 'JetBrains Mono', 'Fira Code', ui-monospace, 'SFMono-Regular', Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace",
+      "margins": 16,
+      "gap": 12,
+      "layout": "grid"
+    },
+    "defaults": { "w": 4, "h": 2, "classes": "" }
+  },
+  "elements": [
+    {
+      "id": "mediaNavbar",
+      "type": "navbar",
+      "label": "Media control deck",
+      "side": "top",
+      "defaults": { "presentation": "notification", "timeoutMs": 3200 },
+      "elements": [
+        {
+          "id": "navMediaMain",
+          "type": "button",
+          "label": "Main layout",
+          "command": {
+            "client": {
+              "loadConfig": {
+                "useDefault": true,
+                "label": "Primary interface",
+                "loadingMessage": "Loading main interface…"
+              }
+            }
+          }
+        },
+        {
+          "id": "navMediaAlt",
+          "type": "button",
+          "label": "Alternate layout",
+          "command": {
+            "client": {
+              "loadConfig": {
+                "name": "ui.alt",
+                "label": "Alternate interface",
+                "loadingMessage": "Loading alternate interface…"
+              }
+            }
+          }
+        },
+        {
+          "id": "navMediaOps",
+          "type": "button",
+          "label": "Ops board",
+          "command": {
+            "client": {
+              "loadConfig": {
+                "name": "ui.ops",
+                "label": "Operations board",
+                "loadingMessage": "Opening operations board…"
+              }
+            }
+          }
+        },
+        {
+          "id": "navMediaDiag",
+          "type": "button",
+          "label": "Diagnostics",
+          "command": {
+            "client": {
+              "loadConfig": {
+                "name": "ui.diagnostics",
+                "label": "Diagnostics interface",
+                "loadingMessage": "Loading diagnostics tools…"
+              }
+            }
+          }
+        },
+        {
+          "id": "navMediaMedia",
+          "type": "button",
+          "label": "Media deck",
+          "tooltip": "Reload media deck",
+          "bg": "rgba(244, 114, 182, 0.18)",
+          "color": "#F472B6",
+          "command": {
+            "client": {
+              "loadConfig": {
+                "name": "ui.media",
+                "label": "Media control deck",
+                "loadingMessage": "Loading media controls…"
+              }
+            }
+          }
+        }
+      ]
+    },
+    {
+      "id": "mediaPlayback",
+      "type": "group",
+      "label": "Playback",
+      "w": 12,
+      "h": 4,
+      "columns": 4,
+      "gap": 12,
+      "border": true,
+      "background": "rgba(30, 27, 75, 0.4)",
+      "elements": [
+        {
+          "id": "mediaPlayPause",
+          "type": "button",
+          "label": "Play / Pause",
+          "sound": "click.mp3",
+          "command": { "server": { "id": "mediaPlayPause", "template": "playerctl play-pause" } },
+          "presentation": "notification",
+          "timeoutMs": 3200,
+          "w": 1
+        },
+        {
+          "id": "mediaNext",
+          "type": "button",
+          "label": "Next track",
+          "command": { "server": { "id": "mediaNext", "template": "playerctl next" } },
+          "presentation": "notification",
+          "timeoutMs": 3200,
+          "w": 1
+        },
+        {
+          "id": "mediaPrevious",
+          "type": "button",
+          "label": "Previous track",
+          "command": { "server": { "id": "mediaPrevious", "template": "playerctl previous" } },
+          "presentation": "notification",
+          "timeoutMs": 3200,
+          "w": 1
+        },
+        {
+          "id": "mediaShuffle",
+          "type": "toggle",
+          "label": "Shuffle",
+          "onCommand": { "server": { "id": "mediaShuffleOn", "template": "playerctl shuffle On" } },
+          "offCommand": { "server": { "id": "mediaShuffleOff", "template": "playerctl shuffle Off" } },
+          "initial": false,
+          "presentation": "notification",
+          "timeoutMs": 3200,
+          "w": 1
+        }
+      ]
+    },
+    {
+      "id": "mediaAudio",
+      "type": "group",
+      "label": "Audio",
+      "w": 12,
+      "h": 4,
+      "columns": 3,
+      "gap": 12,
+      "border": true,
+      "background": "rgba(15, 23, 42, 0.35)",
+      "elements": [
+        {
+          "id": "mediaVolume",
+          "type": "stepper",
+          "label": "Volume",
+          "min": 0,
+          "max": 150,
+          "step": 5,
+          "value": 60,
+          "command": { "server": { "id": "mediaVolume", "template": "pactl set-sink-volume @DEFAULT_SINK@ ${value}%" } },
+          "presentation": "tooltip",
+          "timeoutMs": 4000,
+          "w": 1
+        },
+        {
+          "id": "mediaMute",
+          "type": "toggle",
+          "label": "Mute",
+          "onCommand": { "server": { "id": "mediaMute", "template": "pactl set-sink-mute @DEFAULT_SINK@ 1" } },
+          "offCommand": { "server": { "id": "mediaUnmute", "template": "pactl set-sink-mute @DEFAULT_SINK@ 0" } },
+          "initial": false,
+          "presentation": "notification",
+          "timeoutMs": 3200,
+          "w": 1
+        },
+        {
+          "id": "mediaOutputs",
+          "type": "button",
+          "label": "List outputs",
+          "command": { "server": { "id": "mediaOutputs", "template": "pactl list short sinks" } },
+          "presentation": "modal",
+          "timeoutMs": 7000,
+          "w": 1
+        }
+      ]
+    },
+    {
+      "id": "mediaLibrary",
+      "type": "group",
+      "label": "Library",
+      "w": 12,
+      "h": 5,
+      "columns": 3,
+      "gap": 12,
+      "border": true,
+      "background": "rgba(15, 23, 42, 0.3)",
+      "elements": [
+        {
+          "id": "mediaQueue",
+          "type": "input",
+          "label": "Queue track",
+          "inputType": "string",
+          "apply": {
+            "label": "Queue",
+            "command": { "server": { "id": "mediaQueue", "template": "printf 'Queued %s\\n' ${value}" } }
+          },
+          "presentation": "notification",
+          "timeoutMs": 3200,
+          "w": 1,
+          "h": 3
+        },
+        {
+          "id": "mediaNowPlaying",
+          "type": "output",
+          "label": "Now playing",
+          "command": {
+            "server": {
+              "id": "mediaNowPlaying",
+              "template": "playerctl metadata --format 'Now playing: {{title}} — {{artist}}'"
+            }
+          },
+          "mode": "poll",
+          "intervalMs": 4000,
+          "presentation": "inline",
+          "timeoutMs": 0,
+          "w": 1,
+          "h": 3
+        },
+        {
+          "id": "mediaPlaylist",
+          "type": "output",
+          "label": "Library sample",
+          "command": {
+            "server": {
+              "id": "mediaPlaylist",
+              "template": "ls -1 /music | head -n 20"
+            }
+          },
+          "mode": "manual",
+          "onDemandButtonLabel": "List tracks",
+          "presentation": "popover",
+          "timeoutMs": 6000,
+          "w": 1,
+          "h": 3
+        }
+      ]
+    }
+  ],
+  "whitelist": [
+    "head",
+    "ls",
+    "pactl",
+    "playerctl",
+    "printf"
+  ]
+}

--- a/config/ui.ops.json
+++ b/config/ui.ops.json
@@ -1,0 +1,328 @@
+{
+  "globals": {
+    "theme": {
+      "palette": {
+        "primary": "#0F172A",
+        "accent": "#22D3EE",
+        "surface": "#020617",
+        "muted": "#475569"
+      },
+      "font": "'IBM Plex Mono', 'JetBrains Mono', 'Fira Code', ui-monospace, 'SFMono-Regular', Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace",
+      "margins": 20,
+      "gap": 12,
+      "layout": "grid"
+    },
+    "defaults": { "w": 4, "h": 2, "classes": "" }
+  },
+  "elements": [
+    {
+      "id": "opsNavbar",
+      "type": "navbar",
+      "label": "Operations board",
+      "side": "top",
+      "align": "start",
+      "gap": 12,
+      "defaults": { "presentation": "notification", "timeoutMs": 3200 },
+      "elements": [
+        {
+          "id": "navOpsMain",
+          "type": "button",
+          "label": "Main layout",
+          "command": {
+            "client": {
+              "loadConfig": {
+                "useDefault": true,
+                "label": "Primary interface",
+                "loadingMessage": "Loading main interface…"
+              }
+            }
+          }
+        },
+        {
+          "id": "navOpsAlt",
+          "type": "button",
+          "label": "Alternate layout",
+          "command": {
+            "client": {
+              "loadConfig": {
+                "name": "ui.alt",
+                "label": "Alternate interface",
+                "loadingMessage": "Loading alternate interface…"
+              }
+            }
+          }
+        },
+        {
+          "id": "navOpsOps",
+          "type": "button",
+          "label": "Ops board",
+          "tooltip": "Reload this dashboard",
+          "bg": "rgba(34, 211, 238, 0.18)",
+          "color": "#22D3EE",
+          "command": {
+            "client": {
+              "loadConfig": {
+                "name": "ui.ops",
+                "label": "Operations board",
+                "loadingMessage": "Opening operations board…"
+              }
+            }
+          }
+        },
+        {
+          "id": "navOpsDiagnostics",
+          "type": "button",
+          "label": "Diagnostics",
+          "command": {
+            "client": {
+              "loadConfig": {
+                "name": "ui.diagnostics",
+                "label": "Diagnostics interface",
+                "loadingMessage": "Loading diagnostics tools…"
+              }
+            }
+          }
+        },
+        {
+          "id": "navOpsMedia",
+          "type": "button",
+          "label": "Media deck",
+          "command": {
+            "client": {
+              "loadConfig": {
+                "name": "ui.media",
+                "label": "Media control deck",
+                "loadingMessage": "Loading media controls…"
+              }
+            }
+          }
+        }
+      ]
+    },
+    {
+      "id": "opsSnapshots",
+      "type": "group",
+      "label": "System snapshots",
+      "w": 12,
+      "h": 5,
+      "columns": 4,
+      "gap": 12,
+      "border": true,
+      "background": "rgba(15, 23, 42, 0.35)",
+      "elements": [
+        {
+          "id": "opsUptime",
+          "type": "output",
+          "label": "Uptime",
+          "command": { "server": { "id": "opsUptime", "template": "uptime" } },
+          "mode": "poll",
+          "intervalMs": 10000,
+          "presentation": "inline",
+          "timeoutMs": 0,
+          "h": 3,
+          "w": 1
+        },
+        {
+          "id": "opsLoad",
+          "type": "output",
+          "label": "Load average",
+          "command": { "server": { "id": "opsLoad", "template": "cat /proc/loadavg" } },
+          "mode": "poll",
+          "intervalMs": 8000,
+          "presentation": "tooltip",
+          "timeoutMs": 0,
+          "h": 3,
+          "w": 1
+        },
+        {
+          "id": "opsDisk",
+          "type": "output",
+          "label": "Disk usage",
+          "command": { "server": { "id": "opsDisk", "template": "df -h /" } },
+          "mode": "manual",
+          "onDemandButtonLabel": "Refresh disk",
+          "presentation": "popover",
+          "timeoutMs": 6000,
+          "h": 3,
+          "w": 1
+        },
+        {
+          "id": "opsConnections",
+          "type": "output",
+          "label": "Connections",
+          "command": { "server": { "id": "opsConnections", "template": "ss -s" } },
+          "mode": "manual",
+          "onDemandButtonLabel": "Summarize sockets",
+          "presentation": "inline",
+          "timeoutMs": 6000,
+          "h": 3,
+          "w": 1
+        }
+      ]
+    },
+    {
+      "id": "opsControls",
+      "type": "group",
+      "label": "Operations controls",
+      "w": 12,
+      "h": 4,
+      "columns": 4,
+      "gap": 12,
+      "border": true,
+      "background": "rgba(8, 47, 73, 0.35)",
+      "elements": [
+        {
+          "id": "opsDeploy",
+          "type": "button",
+          "label": "Trigger deploy",
+          "tooltip": "Queue a deployment job",
+          "sound": "click.mp3",
+          "command": { "server": { "id": "opsDeploy", "template": "printf 'Deployment request queued\\n'" } },
+          "presentation": "notification",
+          "timeoutMs": 3200,
+          "w": 1
+        },
+        {
+          "id": "opsServiceStatus",
+          "type": "button",
+          "label": "Service status",
+          "tooltip": "Check running services",
+          "command": {
+            "server": {
+              "id": "opsServiceStatus",
+              "template": "systemctl --no-pager --type=service --state=running | head -n 20"
+            }
+          },
+          "presentation": "modal",
+          "timeoutMs": 8000,
+          "w": 1
+        },
+        {
+          "id": "opsMaintenance",
+          "type": "toggle",
+          "label": "Maintenance mode",
+          "onCommand": { "server": { "id": "opsMaintenanceOn", "template": "printf 'Maintenance mode enabled\\n'" } },
+          "offCommand": { "server": { "id": "opsMaintenanceOff", "template": "printf 'Maintenance mode disabled\\n'" } },
+          "initial": false,
+          "presentation": "notification",
+          "timeoutMs": 3200,
+          "w": 1
+        },
+        {
+          "id": "opsLogLevel",
+          "type": "stepper",
+          "label": "Log level",
+          "min": 1,
+          "max": 5,
+          "step": 1,
+          "value": 3,
+          "command": { "server": { "id": "opsLogLevel", "template": "printf 'Log level set to %s\\n' ${value}" } },
+          "presentation": "tooltip",
+          "timeoutMs": 4000,
+          "w": 1
+        }
+      ]
+    },
+    {
+      "id": "opsLogs",
+      "type": "group",
+      "label": "Log review",
+      "w": 12,
+      "h": 5,
+      "columns": 2,
+      "gap": 12,
+      "border": true,
+      "background": "rgba(15, 23, 42, 0.3)",
+      "elements": [
+        {
+          "id": "opsRecentLogs",
+          "type": "output",
+          "label": "Recent log files",
+          "command": { "server": { "id": "opsRecentLogs", "template": "ls -1t /var/log | head -n 8" } },
+          "mode": "manual",
+          "onDemandButtonLabel": "List files",
+          "presentation": "inline",
+          "timeoutMs": 6000,
+          "h": 3,
+          "w": 1
+        },
+        {
+          "id": "opsErrorStream",
+          "type": "output",
+          "label": "Error stream",
+          "command": {
+            "server": {
+              "id": "opsErrorStream",
+              "template": "journalctl -p 3 -n 20 --no-pager"
+            }
+          },
+          "mode": "manual",
+          "onDemandButtonLabel": "Tail errors",
+          "presentation": "popover",
+          "timeoutMs": 8000,
+          "h": 3,
+          "w": 1
+        }
+      ]
+    },
+    {
+      "id": "opsInvestigations",
+      "type": "group",
+      "label": "Investigations",
+      "w": 12,
+      "h": 4,
+      "columns": 2,
+      "gap": 12,
+      "border": true,
+      "background": "rgba(15, 23, 42, 0.25)",
+      "elements": [
+        {
+          "id": "opsInspectService",
+          "type": "input",
+          "label": "Inspect service log",
+          "inputType": "string",
+          "apply": {
+            "label": "Read log",
+            "command": {
+              "server": {
+                "id": "opsInspectService",
+                "template": "journalctl -u ${value} -n 40 --no-pager"
+              }
+            }
+          },
+          "presentation": "modal",
+          "timeoutMs": 8000,
+          "w": 1,
+          "h": 3
+        },
+        {
+          "id": "opsTailSyslog",
+          "type": "button",
+          "label": "Tail syslog",
+          "command": {
+            "server": {
+              "id": "opsTailSyslog",
+              "template": "tail -n 40 /var/log/syslog"
+            }
+          },
+          "presentation": "inline",
+          "timeoutMs": 7000,
+          "w": 1,
+          "h": 3
+        }
+      ]
+    }
+  ],
+  "whitelist": [
+    "cat",
+    "df",
+    "head",
+    "journalctl",
+    "ls",
+    "printf",
+    "ss",
+    "systemctl",
+    "tail",
+    "uptime"
+  ]
+}

--- a/config/ui.sample.json
+++ b/config/ui.sample.json
@@ -22,16 +22,25 @@
       "defaults": { "presentation": "notification", "timeoutMs": 4000 },
       "elements": [
         {
-          "id": "navFastfetch",
+          "id": "navMainLayout",
           "type": "button",
-          "label": "Run fastfetch",
-          "command": { "server": { "id": "fastfetchQuick", "template": "fastfetch --logo none" } }
+          "label": "Main layout",
+          "tooltip": "Reload the primary controls",
+          "command": {
+            "client": {
+              "loadConfig": {
+                "useDefault": true,
+                "label": "Primary interface",
+                "loadingMessage": "Loading main interface…"
+              }
+            }
+          }
         },
         {
-          "id": "navSwitchUi",
+          "id": "navAltLayout",
           "type": "button",
           "label": "Alternate layout",
-          "tooltip": "Load another interface without reloading",
+          "tooltip": "Load the alternate grid without reloading",
           "command": {
             "client": {
               "loadConfig": {
@@ -41,6 +50,57 @@
               }
             }
           }
+        },
+        {
+          "id": "navOpsLayout",
+          "type": "button",
+          "label": "Ops board",
+          "tooltip": "Switch to the operations dashboard",
+          "command": {
+            "client": {
+              "loadConfig": {
+                "name": "ui.ops",
+                "label": "Operations board",
+                "loadingMessage": "Opening operations board…"
+              }
+            }
+          }
+        },
+        {
+          "id": "navDiagnosticsLayout",
+          "type": "button",
+          "label": "Diagnostics",
+          "tooltip": "Open the diagnostics-focused controls",
+          "command": {
+            "client": {
+              "loadConfig": {
+                "name": "ui.diagnostics",
+                "label": "Diagnostics interface",
+                "loadingMessage": "Loading diagnostics tools…"
+              }
+            }
+          }
+        },
+        {
+          "id": "navMediaLayout",
+          "type": "button",
+          "label": "Media deck",
+          "tooltip": "Jump to media controls",
+          "command": {
+            "client": {
+              "loadConfig": {
+                "name": "ui.media",
+                "label": "Media control deck",
+                "loadingMessage": "Loading media controls…"
+              }
+            }
+          }
+        },
+        {
+          "id": "navFastfetch",
+          "type": "button",
+          "label": "Run fastfetch",
+          "command": { "server": { "id": "fastfetchQuick", "template": "fastfetch --logo none" } }
         },
         {
           "id": "navViewFile",


### PR DESCRIPTION
## Summary
- extend the default and alternate sample configs with navbar buttons that swap between all available layouts
- add dedicated operations, diagnostics, and media example dashboards with symmetrical grids and varied controls

## Testing
- for file in config/ui.sample.json config/ui.alt.json config/ui.ops.json config/ui.diagnostics.json config/ui.media.json; do jq empty "$file"; done

------
https://chatgpt.com/codex/tasks/task_e_68cc6c2954f0832d9a18377f7c3cdeef