### PR TITLE
Add curated sample UI configurations with screenshots

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,20 @@
 LocalUI is a tiny PHP web interface that renders controls defined in JSON and safely executes whitelisted shell commands on your machine. It is intended for localhost use with the built-in PHP server.
 <img width="1280" height="1302" alt="image" src="https://github.com/user-attachments/assets/b333ae00-905c-4c5d-984c-37e46820c7b2" />
 
+Additional ready-to-run layouts are available in `config/`. Screenshots for each layout accompany this release in the project conversation thread.
+
+- [`ui.operations.json`](config/ui.operations.json) — control-room style dashboard for runtime operations with grouped actions, live metrics, and file tools.
+- [`ui.triage.json`](config/ui.triage.json) — incident triage workspace with stacked status blocks, log tooling, and safety toggles.
+- [`ui.workspace.json`](config/ui.workspace.json) — repository-focused cockpit with project summaries, environment checks, and repository utilities.
+
+Swap any of them into place with:
+
+```sh
+cp config/ui.operations.json config/ui.json
+```
+
+Then reload the browser to explore the layout.
+
 
 ## Requirements
 - PHP 8.1 or newer with `proc_open` enabled

--- a/config/ui.operations.json
+++ b/config/ui.operations.json
@@ -1,0 +1,257 @@
+{
+  "globals": {
+    "theme": {
+      "palette": {
+        "primary": "#0F172A",
+        "accent": "#22D3EE",
+        "surface": "#020617",
+        "muted": "#94A3B8",
+        "danger": "#FCA5A5"
+      },
+      "font": "'IBM Plex Mono', 'JetBrains Mono', 'Fira Code', ui-monospace, 'SFMono-Regular', Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace",
+      "margins": 24,
+      "gap": 16,
+      "layout": "grid"
+    },
+    "defaults": {
+      "w": 4,
+      "h": 2,
+      "classes": "rounded-xl border border-slate-700/60 bg-slate-900/60 backdrop-blur"
+    }
+  },
+  "elements": [
+    {
+      "id": "quickActions",
+      "type": "group",
+      "label": "Quick actions",
+      "w": 12,
+      "h": 3,
+      "x": 0,
+      "y": 0,
+      "columns": 12,
+      "gap": 12,
+      "border": true,
+      "background": "rgba(15, 23, 42, 0.6)",
+      "elements": [
+        {
+          "id": "uptimeCheck",
+          "type": "button",
+          "label": "Check uptime",
+          "tooltip": "Shows the current uptime as a toast notification",
+          "sound": "click.mp3",
+          "command": { "server": { "id": "ops_uptime", "template": "uptime" } },
+          "presentation": "notification",
+          "timeoutMs": 4000,
+          "w": 3,
+          "h": 2,
+          "x": 0,
+          "y": 0
+        },
+        {
+          "id": "activeUsers",
+          "type": "button",
+          "label": "Active users",
+          "tooltip": "Lists logged in users",
+          "sound": "click.mp3",
+          "command": { "server": { "id": "ops_who", "template": "who" } },
+          "presentation": "popover",
+          "timeoutMs": 5000,
+          "w": 3,
+          "h": 2,
+          "x": 3,
+          "y": 0
+        },
+        {
+          "id": "maintenanceToggle",
+          "type": "toggle",
+          "label": "Maintenance mode",
+          "sound": "click.mp3",
+          "onCommand": { "server": { "id": "ops_maintenance_on", "template": "echo Maintenance mode ENABLED" } },
+          "offCommand": { "server": { "id": "ops_maintenance_off", "template": "echo Maintenance mode DISABLED" } },
+          "initial": false,
+          "presentation": "inline",
+          "timeoutMs": 0,
+          "w": 3,
+          "h": 2,
+          "x": 6,
+          "y": 0
+        },
+        {
+          "id": "workspaceListing",
+          "type": "button",
+          "label": "List /workspace",
+          "tooltip": "Inspect files in /workspace",
+          "sound": "click.mp3",
+          "command": { "server": { "id": "ops_list_workspace", "template": "ls -lah /workspace" } },
+          "presentation": "popover",
+          "timeoutMs": 6000,
+          "w": 3,
+          "h": 2,
+          "x": 9,
+          "y": 0
+        }
+      ]
+    },
+    {
+      "id": "systemMonitors",
+      "type": "group",
+      "label": "System monitors",
+      "w": 8,
+      "h": 11,
+      "x": 0,
+      "y": 3,
+      "columns": 8,
+      "gap": 12,
+      "border": "1px solid rgba(148, 163, 184, 0.3)",
+      "background": "rgba(15, 23, 42, 0.5)",
+      "elements": [
+        {
+          "id": "diskUsage",
+          "type": "output",
+          "label": "Disk usage",
+          "command": { "server": { "id": "ops_disk_usage", "template": "df -h /" } },
+          "mode": "poll",
+          "intervalMs": 8000,
+          "presentation": "inline",
+          "timeoutMs": 0,
+          "w": 4,
+          "h": 3,
+          "x": 0,
+          "y": 0
+        },
+        {
+          "id": "memoryUsage",
+          "type": "output",
+          "label": "Memory usage",
+          "command": { "server": { "id": "ops_memory", "template": "free -h" } },
+          "mode": "poll",
+          "intervalMs": 8000,
+          "presentation": "inline",
+          "timeoutMs": 0,
+          "w": 4,
+          "h": 3,
+          "x": 4,
+          "y": 0
+        },
+        {
+          "id": "kernelInfo",
+          "type": "output",
+          "label": "Kernel",
+          "command": { "server": { "id": "ops_kernel", "template": "uname -a" } },
+          "mode": "manual",
+          "onDemandButtonLabel": "Show kernel info",
+          "presentation": "tooltip",
+          "timeoutMs": 5000,
+          "w": 8,
+          "h": 2,
+          "x": 0,
+          "y": 3
+        },
+        {
+          "id": "processTop",
+          "type": "output",
+          "label": "Top processes",
+          "command": { "server": { "id": "ops_processes", "template": "sh -c \"ps -eo pid,comm,%cpu,%mem --sort=-%mem | head -n 12\"" } },
+          "mode": "manual",
+          "onDemandButtonLabel": "Inspect processes",
+          "presentation": "modal",
+          "timeoutMs": 9000,
+          "w": 8,
+          "h": 3,
+          "x": 0,
+          "y": 5
+        },
+        {
+          "id": "dpkgTail",
+          "type": "output",
+          "label": "Recent package log",
+          "command": { "server": { "id": "ops_dpkg_tail", "template": "tail -n 40 /var/log/dpkg.log" } },
+          "mode": "poll",
+          "intervalMs": 15000,
+          "presentation": "notification",
+          "timeoutMs": 9000,
+          "w": 8,
+          "h": 3,
+          "x": 0,
+          "y": 8
+        }
+      ]
+    },
+    {
+      "id": "fileTools",
+      "type": "group",
+      "label": "File tools",
+      "w": 4,
+      "h": 11,
+      "x": 8,
+      "y": 3,
+      "columns": 4,
+      "gap": 12,
+      "border": "1px solid rgba(56, 189, 248, 0.35)",
+      "background": "rgba(30, 41, 59, 0.55)",
+      "elements": [
+        {
+          "id": "filePreview",
+          "type": "input",
+          "label": "Preview file",
+          "inputType": "string",
+          "tooltip": "Reads a text file",
+          "apply": {
+            "label": "Read file",
+            "command": { "server": { "id": "ops_read_file", "template": "cat ${value}" } }
+          },
+          "presentation": "modal",
+          "timeoutMs": 8000,
+          "w": 4,
+          "h": 4,
+          "x": 0,
+          "y": 0
+        },
+        {
+          "id": "logDepth",
+          "type": "stepper",
+          "label": "Log tail lines",
+          "min": 10,
+          "max": 100,
+          "step": 10,
+          "value": 30,
+          "command": { "server": { "id": "ops_tail_depth", "template": "tail -n ${value} /var/log/dpkg.log" } },
+          "presentation": "popover",
+          "timeoutMs": 6000,
+          "w": 4,
+          "h": 2,
+          "x": 0,
+          "y": 4
+        },
+        {
+          "id": "workspaceTree",
+          "type": "output",
+          "label": "Repository tree",
+          "command": { "server": { "id": "ops_repo_tree", "template": "ls -lah" } },
+          "mode": "manual",
+          "onDemandButtonLabel": "List root",
+          "presentation": "inline",
+          "timeoutMs": 6000,
+          "w": 4,
+          "h": 3,
+          "x": 0,
+          "y": 6
+        }
+      ]
+    }
+  ],
+  "whitelist": [
+    "uptime",
+    "who",
+    "echo",
+    "ls",
+    "df",
+    "free",
+    "uname",
+    "ps",
+    "head",
+    "tail",
+    "cat",
+    "sh"
+  ]
+}

--- a/config/ui.triage.json
+++ b/config/ui.triage.json
@@ -1,0 +1,228 @@
+{
+  "globals": {
+    "theme": {
+      "palette": {
+        "primary": "#111827",
+        "accent": "#F97316",
+        "surface": "#0B1120",
+        "muted": "#FCD34D",
+        "danger": "#F87171"
+      },
+      "font": "'Fira Mono', 'JetBrains Mono', 'Fira Code', ui-monospace, 'SFMono-Regular', Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace",
+      "margins": 28,
+      "gap": 18,
+      "layout": "stack"
+    },
+    "defaults": {
+      "w": 12,
+      "h": 3,
+      "classes": "rounded-lg border border-amber-500/30 bg-slate-950/60 shadow-lg"
+    }
+  },
+  "elements": [
+    {
+      "id": "statusBoard",
+      "type": "group",
+      "label": "Live status",
+      "layout": "grid",
+      "columns": 12,
+      "gap": 14,
+      "border": "1px solid rgba(249, 115, 22, 0.35)",
+      "background": "rgba(17, 24, 39, 0.75)",
+      "elements": [
+        {
+          "id": "uptimeStatus",
+          "type": "output",
+          "label": "Uptime",
+          "command": { "server": { "id": "triage_uptime", "template": "uptime" } },
+          "mode": "poll",
+          "intervalMs": 10000,
+          "presentation": "inline",
+          "timeoutMs": 0,
+          "w": 6,
+          "h": 2,
+          "x": 0,
+          "y": 0
+        },
+        {
+          "id": "clock",
+          "type": "output",
+          "label": "Clock",
+          "command": { "server": { "id": "triage_clock", "template": "date \"+%Y-%m-%d %H:%M:%S\"" } },
+          "mode": "poll",
+          "intervalMs": 1000,
+          "presentation": "inline",
+          "timeoutMs": 0,
+          "w": 6,
+          "h": 2,
+          "x": 6,
+          "y": 0
+        },
+        {
+          "id": "hostIdentity",
+          "type": "output",
+          "label": "Hostname",
+          "command": { "server": { "id": "triage_hostname", "template": "hostname" } },
+          "mode": "manual",
+          "onDemandButtonLabel": "Read host",
+          "presentation": "tooltip",
+          "timeoutMs": 4000,
+          "w": 6,
+          "h": 2,
+          "x": 0,
+          "y": 2
+        },
+        {
+          "id": "environmentSnapshot",
+          "type": "button",
+          "label": "Capture environment",
+          "sound": "click.mp3",
+          "command": { "server": { "id": "triage_env", "template": "env" } },
+          "presentation": "modal",
+          "timeoutMs": 9000,
+          "w": 12,
+          "h": 2,
+          "x": 0,
+          "y": 4
+        }
+      ]
+    },
+    {
+      "id": "logInspector",
+      "type": "group",
+      "label": "Log inspector",
+      "layout": "grid",
+      "columns": 12,
+      "gap": 12,
+      "border": true,
+      "background": "rgba(30, 41, 59, 0.6)",
+      "elements": [
+        {
+          "id": "logLines",
+          "type": "stepper",
+          "label": "Tail lines",
+          "min": 20,
+          "max": 200,
+          "step": 20,
+          "value": 60,
+          "command": { "server": { "id": "triage_log_depth", "template": "tail -n ${value} /var/log/dpkg.log" } },
+          "presentation": "popover",
+          "timeoutMs": 6000,
+          "w": 4,
+          "h": 2,
+          "x": 0,
+          "y": 0
+        },
+        {
+          "id": "tailPreview",
+          "type": "output",
+          "label": "dpkg.log tail",
+          "command": { "server": { "id": "triage_tail", "template": "tail -n 40 /var/log/dpkg.log" } },
+          "mode": "manual",
+          "onDemandButtonLabel": "Tail log",
+          "presentation": "inline",
+          "timeoutMs": 7000,
+          "w": 8,
+          "h": 3,
+          "x": 4,
+          "y": 0
+        },
+        {
+          "id": "searchLogs",
+          "type": "input",
+          "label": "Search dpkg.log",
+          "inputType": "string",
+          "apply": {
+            "label": "Search",
+            "command": { "server": { "id": "triage_search", "template": "grep -n ${value} /var/log/dpkg.log" } }
+          },
+          "presentation": "modal",
+          "timeoutMs": 9000,
+          "w": 12,
+          "h": 3,
+          "x": 0,
+          "y": 3
+        }
+      ]
+    },
+    {
+      "id": "commandPad",
+      "type": "group",
+      "label": "Command pad",
+      "layout": "grid",
+      "columns": 12,
+      "gap": 14,
+      "border": "1px solid rgba(37, 99, 235, 0.35)",
+      "background": "rgba(15, 23, 42, 0.65)",
+      "elements": [
+        {
+          "id": "listWorkspace",
+          "type": "button",
+          "label": "List workspace",
+          "sound": "click.mp3",
+          "command": { "server": { "id": "triage_list_workspace", "template": "ls -lah /workspace" } },
+          "presentation": "popover",
+          "timeoutMs": 6000,
+          "w": 4,
+          "h": 2,
+          "x": 0,
+          "y": 0
+        },
+        {
+          "id": "osRelease",
+          "type": "button",
+          "label": "OS release",
+          "sound": "click.mp3",
+          "command": { "server": { "id": "triage_os_release", "template": "cat /etc/os-release" } },
+          "presentation": "modal",
+          "timeoutMs": 8000,
+          "w": 4,
+          "h": 2,
+          "x": 4,
+          "y": 0
+        },
+        {
+          "id": "deployToggle",
+          "type": "toggle",
+          "label": "Deploy freeze",
+          "sound": "click.mp3",
+          "onCommand": { "server": { "id": "triage_freeze_on", "template": "echo Deployments frozen" } },
+          "offCommand": { "server": { "id": "triage_freeze_off", "template": "echo Deployments resumed" } },
+          "initial": true,
+          "presentation": "inline",
+          "timeoutMs": 0,
+          "w": 4,
+          "h": 2,
+          "x": 8,
+          "y": 0
+        },
+        {
+          "id": "currentUser",
+          "type": "output",
+          "label": "Current user",
+          "command": { "server": { "id": "triage_user", "template": "whoami" } },
+          "mode": "manual",
+          "onDemandButtonLabel": "Check user",
+          "presentation": "tooltip",
+          "timeoutMs": 4000,
+          "w": 4,
+          "h": 2,
+          "x": 0,
+          "y": 2
+        }
+      ]
+    }
+  ],
+  "whitelist": [
+    "uptime",
+    "date",
+    "hostname",
+    "env",
+    "tail",
+    "grep",
+    "cat",
+    "ls",
+    "echo",
+    "whoami"
+  ]
+}

--- a/config/ui.workspace.json
+++ b/config/ui.workspace.json
@@ -1,0 +1,235 @@
+{
+  "globals": {
+    "theme": {
+      "palette": {
+        "primary": "#1D4ED8",
+        "accent": "#10B981",
+        "surface": "#F8FAFC",
+        "muted": "#64748B",
+        "danger": "#EF4444"
+      },
+      "font": "'Inter var', 'Inter', 'Segoe UI', system-ui, -apple-system, sans-serif",
+      "margins": 32,
+      "gap": 20,
+      "layout": "grid"
+    },
+    "defaults": {
+      "w": 6,
+      "h": 2,
+      "classes": "rounded-xl bg-white/10 border border-slate-200/20 text-slate-100 shadow-xl"
+    }
+  },
+  "elements": [
+    {
+      "id": "workspaceSummary",
+      "type": "group",
+      "label": "Workspace summary",
+      "w": 12,
+      "h": 3,
+      "x": 0,
+      "y": 0,
+      "columns": 12,
+      "gap": 12,
+      "border": "1px solid rgba(15, 23, 42, 0.15)",
+      "background": "rgba(15, 23, 42, 0.35)",
+      "elements": [
+        {
+          "id": "gitStatus",
+          "type": "button",
+          "label": "Git status",
+          "sound": "click.mp3",
+          "command": { "server": { "id": "workspace_git_status", "template": "sh -c \"cd /workspace/LocalUI && git status -sb\"" } },
+          "presentation": "modal",
+          "timeoutMs": 9000,
+          "w": 4,
+          "h": 2,
+          "x": 0,
+          "y": 0
+        },
+        {
+          "id": "readReadme",
+          "type": "button",
+          "label": "Read README",
+          "sound": "click.mp3",
+          "command": { "server": { "id": "workspace_readme", "template": "cat README.md" } },
+          "presentation": "popover",
+          "timeoutMs": 7000,
+          "w": 4,
+          "h": 2,
+          "x": 4,
+          "y": 0
+        },
+        {
+          "id": "listConfig",
+          "type": "button",
+          "label": "List configs",
+          "sound": "click.mp3",
+          "command": { "server": { "id": "workspace_list_configs", "template": "ls -lah config" } },
+          "presentation": "tooltip",
+          "timeoutMs": 5000,
+          "w": 4,
+          "h": 2,
+          "x": 8,
+          "y": 0
+        },
+        {
+          "id": "debugToggle",
+          "type": "toggle",
+          "label": "Debug logging",
+          "sound": "click.mp3",
+          "onCommand": { "server": { "id": "workspace_debug_on", "template": "echo Debug logging ENABLED" } },
+          "offCommand": { "server": { "id": "workspace_debug_off", "template": "echo Debug logging DISABLED" } },
+          "initial": false,
+          "presentation": "inline",
+          "timeoutMs": 0,
+          "w": 4,
+          "h": 2,
+          "x": 0,
+          "y": 2
+        }
+      ]
+    },
+    {
+      "id": "workspaceOutputs",
+      "type": "group",
+      "label": "Workspace outputs",
+      "w": 7,
+      "h": 10,
+      "x": 0,
+      "y": 3,
+      "columns": 7,
+      "gap": 12,
+      "border": "1px solid rgba(148, 163, 184, 0.25)",
+      "background": "rgba(226, 232, 240, 0.08)",
+      "elements": [
+        {
+          "id": "repoTree",
+          "type": "output",
+          "label": "Repository tree",
+          "command": { "server": { "id": "workspace_repo_tree", "template": "ls -lah /workspace/LocalUI" } },
+          "mode": "manual",
+          "onDemandButtonLabel": "List repo",
+          "presentation": "inline",
+          "timeoutMs": 7000,
+          "w": 7,
+          "h": 3,
+          "x": 0,
+          "y": 0
+        },
+        {
+          "id": "diskFootprint",
+          "type": "output",
+          "label": "Disk footprint",
+          "command": { "server": { "id": "workspace_disk", "template": "du -sh /workspace/LocalUI" } },
+          "mode": "poll",
+          "intervalMs": 15000,
+          "presentation": "inline",
+          "timeoutMs": 0,
+          "w": 7,
+          "h": 2,
+          "x": 0,
+          "y": 3
+        },
+        {
+          "id": "phpVersion",
+          "type": "output",
+          "label": "PHP version",
+          "command": { "server": { "id": "workspace_php_version", "template": "php -v" } },
+          "mode": "manual",
+          "onDemandButtonLabel": "Check PHP",
+          "presentation": "popover",
+          "timeoutMs": 6000,
+          "w": 7,
+          "h": 2,
+          "x": 0,
+          "y": 5
+        },
+        {
+          "id": "recentCommits",
+          "type": "output",
+          "label": "Recent commits",
+          "command": { "server": { "id": "workspace_commits", "template": "sh -c \"cd /workspace/LocalUI && git log --oneline -5\"" } },
+          "mode": "manual",
+          "onDemandButtonLabel": "Show commits",
+          "presentation": "modal",
+          "timeoutMs": 9000,
+          "w": 7,
+          "h": 3,
+          "x": 0,
+          "y": 7
+        }
+      ]
+    },
+    {
+      "id": "projectInsights",
+      "type": "group",
+      "label": "Project insights",
+      "w": 5,
+      "h": 10,
+      "x": 7,
+      "y": 3,
+      "columns": 5,
+      "gap": 12,
+      "border": "1px solid rgba(37, 99, 235, 0.35)",
+      "background": "rgba(59, 130, 246, 0.15)",
+      "elements": [
+        {
+          "id": "viewFile",
+          "type": "input",
+          "label": "View file in repo",
+          "inputType": "string",
+          "apply": {
+            "label": "Open file",
+            "command": { "server": { "id": "workspace_view_file", "template": "cat /workspace/LocalUI/${value}" } }
+          },
+          "presentation": "modal",
+          "timeoutMs": 8000,
+          "w": 5,
+          "h": 4,
+          "x": 0,
+          "y": 0
+        },
+        {
+          "id": "listHead",
+          "type": "stepper",
+          "label": "List repo head",
+          "min": 5,
+          "max": 30,
+          "step": 5,
+          "value": 15,
+          "command": { "server": { "id": "workspace_list_head", "template": "sh -c \"cd /workspace/LocalUI && ls -lah | head -n ${value}\"" } },
+          "presentation": "popover",
+          "timeoutMs": 6000,
+          "w": 5,
+          "h": 2,
+          "x": 0,
+          "y": 4
+        },
+        {
+          "id": "currentUser",
+          "type": "output",
+          "label": "Current user",
+          "command": { "server": { "id": "workspace_user", "template": "whoami" } },
+          "mode": "manual",
+          "onDemandButtonLabel": "Check user",
+          "presentation": "tooltip",
+          "timeoutMs": 4000,
+          "w": 5,
+          "h": 2,
+          "x": 0,
+          "y": 6
+        }
+      ]
+    }
+  ],
+  "whitelist": [
+    "sh",
+    "git",
+    "cat",
+    "ls",
+    "echo",
+    "du",
+    "php",
+    "whoami"
+  ]
+}


### PR DESCRIPTION
## Summary
- add three curated sample UI configurations covering operations, incident triage, and repository management use cases
- document where to find matching screenshots in the README while keeping the repository free of binary assets

## Testing
- jq empty config/ui.operations.json
- jq empty config/ui.triage.json
- jq empty config/ui.workspace.json
- php -S 0.0.0.0:8000 -t public (manual verification while capturing screenshots)


------
https://chatgpt.com/codex/tasks/task_e_68cc817e6eac832dada35bda135f3706