### PR TITLE
Refine editor snapping and design surface controls

### DIFF
--- a/lib/Defaults.php
+++ b/lib/Defaults.php
@@ -19,6 +19,11 @@ class Defaults
                     'gap' => 8,
                     'layout' => 'grid',
                 ],
+                'surface' => [
+                    'width' => 1200,
+                    'height' => 720,
+                    'gridSize' => 48,
+                ],
                 'defaults' => [
                     'w' => 12,
                     'h' => 2,

--- a/public/css/custom.css
+++ b/public/css/custom.css
@@ -64,9 +64,28 @@ body {
 .component-group-body {
   min-height: 0;
   width: 100%;
+}
+
+.component-group-body[data-layout="stack"] {
   display: flex;
   flex-direction: column;
   gap: 1rem;
+}
+
+.component-group-body[data-layout="freeform"] {
+  position: relative;
+  display: block;
+  min-height: 100%;
+}
+
+.ui-freeform-surface {
+  position: relative;
+  overflow: visible;
+}
+
+.ui-freeform-surface [data-element-id],
+.ui-freeform-surface [data-group-id] {
+  position: absolute;
 }
 
 .component-card:hover {

--- a/public/editor.php
+++ b/public/editor.php
@@ -17,6 +17,8 @@ $fontStack = $config['globals']['theme']['font'] ?? '\'JetBrainsMono Nerd Font\'
 $primary = $config['globals']['theme']['palette']['primary'] ?? '#111827';
 $accent = $config['globals']['theme']['palette']['accent'] ?? '#10B981';
 $surface = $config['globals']['theme']['palette']['surface'] ?? '#F8FAFC';
+$muted = $config['globals']['theme']['palette']['muted'] ?? '#94A3B8';
+$danger = $config['globals']['theme']['palette']['danger'] ?? '#F87171';
 ?>
 <!DOCTYPE html>
 <html lang="en">
@@ -32,6 +34,8 @@ $surface = $config['globals']['theme']['palette']['surface'] ?? '#F8FAFC';
             --primary-color: <?= htmlspecialchars($primary, ENT_QUOTES, 'UTF-8'); ?>;
             --accent-color: <?= htmlspecialchars($accent, ENT_QUOTES, 'UTF-8'); ?>;
             --surface-color: <?= htmlspecialchars($surface, ENT_QUOTES, 'UTF-8'); ?>;
+            --muted-color: <?= htmlspecialchars($muted, ENT_QUOTES, 'UTF-8'); ?>;
+            --danger-color: <?= htmlspecialchars($danger, ENT_QUOTES, 'UTF-8'); ?>;
         }
         body {
             font-family: <?= htmlspecialchars($fontStack, ENT_QUOTES, 'UTF-8'); ?>;

--- a/public/index.php
+++ b/public/index.php
@@ -14,6 +14,8 @@ $fontStack = $config['globals']['theme']['font'] ?? '\'JetBrainsMono Nerd Font\'
 $primary = $config['globals']['theme']['palette']['primary'] ?? '#111827';
 $accent = $config['globals']['theme']['palette']['accent'] ?? '#10B981';
 $surface = $config['globals']['theme']['palette']['surface'] ?? '#F8FAFC';
+$muted = $config['globals']['theme']['palette']['muted'] ?? '#94A3B8';
+$danger = $config['globals']['theme']['palette']['danger'] ?? '#F87171';
 ?>
 <!DOCTYPE html>
 <html lang="en">
@@ -28,6 +30,8 @@ $surface = $config['globals']['theme']['palette']['surface'] ?? '#F8FAFC';
             --primary-color: <?= htmlspecialchars($primary, ENT_QUOTES, 'UTF-8'); ?>;
             --accent-color: <?= htmlspecialchars($accent, ENT_QUOTES, 'UTF-8'); ?>;
             --surface-color: <?= htmlspecialchars($surface, ENT_QUOTES, 'UTF-8'); ?>;
+            --muted-color: <?= htmlspecialchars($muted, ENT_QUOTES, 'UTF-8'); ?>;
+            --danger-color: <?= htmlspecialchars($danger, ENT_QUOTES, 'UTF-8'); ?>;
         }
         body {
             font-family: <?= htmlspecialchars($fontStack, ENT_QUOTES, 'UTF-8'); ?>;

--- a/public/js/modules/init.js
+++ b/public/js/modules/init.js
@@ -1,5 +1,5 @@
 import { createAppState } from './state.js';
-import { setupLayout } from './layout.js';
+import { getSurfaceGridSize, normalizeSurface, setupLayout } from './layout.js';
 import { createOverlayManager } from './overlay.js';
 import { createResultViewFactory } from './presentation.js';
 import { createRenderer } from './renderers.js';
@@ -19,8 +19,13 @@ export function initializeApp(root, config) {
   });
 
   const globals = config.globals || {};
-  const rootLayout = setupLayout(root, globals);
-  const rootContext = { layout: rootLayout, globals };
+  const normalizedGlobals = {
+    ...globals,
+    surface: normalizeSurface(globals.surface || {}),
+  };
+  const rootLayout = setupLayout(root, normalizedGlobals);
+  const gridSize = getSurfaceGridSize(normalizedGlobals);
+  const rootContext = { layout: rootLayout, globals: normalizedGlobals, grid: gridSize };
 
   (config.elements || []).forEach((element) => {
     renderer.renderEntity(element, root, rootContext);

--- a/public/js/modules/layout.js
+++ b/public/js/modules/layout.js
@@ -1,5 +1,15 @@
+export const DEFAULT_GRID_SCALE = 48;
+export const DEFAULT_SURFACE_WIDTH = 1200;
+export const DEFAULT_SURFACE_HEIGHT = 720;
+
 export function normalizeLayout(value) {
-  return value === 'grid' ? 'grid' : 'stack';
+  if (value === 'stack') {
+    return 'stack';
+  }
+  if (value === 'freeform' || value === 'free') {
+    return 'freeform';
+  }
+  return 'freeform';
 }
 
 export function setupLayout(container, globals = {}) {
@@ -8,14 +18,73 @@ export function setupLayout(container, globals = {}) {
   const layout = normalizeLayout(theme.layout);
   const gap = theme.gap ?? 8;
   const margin = theme.margins ?? 12;
+  const surface = normalizeSurface(globals.surface);
 
-  if (layout === 'grid') {
-    container.classList.add('grid', 'auto-rows-min', 'sm:grid-cols-2', 'xl:grid-cols-12');
-  } else {
-    container.classList.add('flex', 'flex-col');
-  }
   container.dataset.layout = layout;
-  container.style.gap = `${gap}px`;
   container.style.padding = `${margin}px`;
+
+  if (layout === 'stack') {
+    container.classList.add('flex', 'flex-col');
+    container.style.gap = `${gap}px`;
+    container.style.position = '';
+    container.style.width = '';
+    container.style.height = '';
+    container.style.removeProperty('--freeform-gap');
+  } else {
+    container.classList.add('ui-freeform-surface');
+    container.style.position = 'relative';
+    container.style.width = surface.width ? `${surface.width}px` : '';
+    container.style.height = surface.height ? `${surface.height}px` : '';
+    container.style.setProperty('--freeform-gap', `${gap}px`);
+    container.style.gap = '';
+  }
+
+  applyThemeStyles(theme);
+
   return layout;
+}
+
+export function applyThemeStyles(theme = {}) {
+  const palette = theme.palette || {};
+  const root = document.documentElement;
+  const body = document.body;
+
+  if (root) {
+    applyRootColor(root, '--primary-color', palette.primary);
+    applyRootColor(root, '--accent-color', palette.accent);
+    applyRootColor(root, '--surface-color', palette.surface);
+    applyRootColor(root, '--muted-color', palette.muted);
+    applyRootColor(root, '--danger-color', palette.danger);
+  }
+
+  if (body && theme.font) {
+    body.style.fontFamily = theme.font;
+  }
+}
+
+function applyRootColor(root, variable, value) {
+  if (!root) {
+    return;
+  }
+  if (value) {
+    root.style.setProperty(variable, value);
+  } else {
+    root.style.removeProperty(variable);
+  }
+}
+
+export function normalizeSurface(surface = {}) {
+  const width = Number(surface.width);
+  const height = Number(surface.height);
+  const gridSize = Number(surface.gridSize);
+  return {
+    width: Number.isFinite(width) && width > 0 ? width : DEFAULT_SURFACE_WIDTH,
+    height: Number.isFinite(height) && height > 0 ? height : DEFAULT_SURFACE_HEIGHT,
+    gridSize: Number.isFinite(gridSize) && gridSize > 0 ? gridSize : DEFAULT_GRID_SCALE,
+  };
+}
+
+export function getSurfaceGridSize(globals = {}, fallback = DEFAULT_GRID_SCALE) {
+  const surface = normalizeSurface(globals.surface || {});
+  return surface.gridSize || fallback;
 }


### PR DESCRIPTION
## Summary
- switch the designer and runtime renderer to absolute positioning so items snap cleanly to the grid without shifting their neighbors
- persist configurable surface dimensions and grid scale, keeping the design surface static unless explicitly changed in the style editor
- ensure theme palette updates immediately by updating CSS variables, including new palette keys for muted and danger colors

## Testing
- php -l public/editor.php
- php -l public/index.php

------
https://chatgpt.com/codex/tasks/task_e_68d561c75b48832d89b7252b903920e5