### PR TITLE
Improve layout sizing and editor grid snapping

### DIFF
--- a/lib/Defaults.php
+++ b/lib/Defaults.php
@@ -15,14 +15,14 @@ class Defaults
                         'danger' => '#F87171',
                     ],
                     'font' => '\'JetBrainsMono Nerd Font\', \'JetBrains Mono\', \'Fira Code\', ui-monospace, \'SFMono-Regular\', Menlo, Monaco, Consolas, \'Liberation Mono\', \'Courier New\', monospace',
-                    'margins' => 12,
-                    'gap' => 8,
+                    'margins' => 24,
+                    'gap' => 16,
                     'layout' => 'grid',
                 ],
                 'surface' => [
                     'width' => 1200,
                     'height' => 720,
-                    'gridSize' => 100,
+                    'gridSize' => null,
                 ],
                 'defaults' => [
                     'w' => 12,

--- a/lib/Defaults.php
+++ b/lib/Defaults.php
@@ -22,7 +22,7 @@ class Defaults
                 'surface' => [
                     'width' => 1200,
                     'height' => 720,
-                    'gridSize' => 48,
+                    'gridSize' => 100,
                 ],
                 'defaults' => [
                     'w' => 12,

--- a/public/css/editor.css
+++ b/public/css/editor.css
@@ -47,6 +47,7 @@
   position: relative;
   border-radius: 0.75rem;
   transition: outline 120ms ease, transform 120ms ease;
+  cursor: move;
 }
 
 .editor-entity.editor-hovered:not(.editor-selected) {
@@ -88,24 +89,37 @@
   display: block;
 }
 
+.editor-root .editor-entity button,
+.editor-root .editor-entity .ui-button,
+.editor-root .editor-entity input,
+.editor-root .editor-entity textarea,
+.editor-root .editor-entity select,
+.editor-root .editor-entity label {
+  pointer-events: none;
+}
+
 .editor-handle-nw {
   top: 0;
   left: 0;
+  cursor: nwse-resize;
 }
 
 .editor-handle-ne {
   top: 0;
   right: 0;
+  cursor: nesw-resize;
 }
 
 .editor-handle-sw {
   bottom: 0;
   left: 0;
+  cursor: nesw-resize;
 }
 
 .editor-handle-se {
   bottom: 0;
   right: 0;
+  cursor: nwse-resize;
 }
 
 .editor-ghost-layer {

--- a/public/js/editor/main.js
+++ b/public/js/editor/main.js
@@ -3,6 +3,7 @@ import {
   DEFAULT_GRID_SCALE,
   DEFAULT_SURFACE_HEIGHT,
   DEFAULT_SURFACE_WIDTH,
+  getSurfaceGridSize,
   normalizeSurface,
   setupLayout,
 } from '../modules/layout.js';
@@ -155,10 +156,13 @@ function cloneConfig(value) {
 
 function getSurfaceSettings(globals = {}) {
   const normalized = normalizeSurface(globals?.surface || {});
+  const inferredGrid = getSurfaceGridSize({ theme: globals?.theme, surface: globals?.surface }, DEFAULT_GRID_SCALE);
+  const gridCandidate = Number(inferredGrid || normalized.gridSize || DEFAULT_GRID_SCALE);
+  const gridValue = Number.isFinite(gridCandidate) ? gridCandidate : DEFAULT_GRID_SCALE;
   return {
     width: Math.max(1, Math.round(normalized.width || DEFAULT_SURFACE_WIDTH)),
     height: Math.max(1, Math.round(normalized.height || DEFAULT_SURFACE_HEIGHT)),
-    gridSize: clamp(Math.round(normalized.gridSize || DEFAULT_GRID_SCALE), MIN_GRID_SCALE, MAX_GRID_SCALE),
+    gridSize: clamp(gridValue, MIN_GRID_SCALE, MAX_GRID_SCALE),
   };
 }
 

--- a/public/js/editor/main.js
+++ b/public/js/editor/main.js
@@ -14,6 +14,13 @@ const MIN_GRID_SCALE = 8;
 const MAX_GRID_SCALE = 160;
 const DRAG_START_THRESHOLD = 4;
 
+function snapToGrid(value, scale) {
+  if (!Number.isFinite(scale) || scale <= 0) {
+    return value;
+  }
+  return Math.round(value / scale) * scale;
+}
+
 const OBJECT_LIBRARY = [
   {
     type: 'button',
@@ -1130,10 +1137,12 @@ function startMoveInteraction(state, event, id, previewEvent = null) {
     }
     const dx = evt.clientX - interaction.startX;
     const dy = evt.clientY - interaction.startY;
-    interaction.deltaX = dx;
-    interaction.deltaY = dy;
+    const snappedDx = snapToGrid(dx, state.grid.scale);
+    const snappedDy = snapToGrid(dy, state.grid.scale);
+    interaction.deltaX = snappedDx;
+    interaction.deltaY = snappedDy;
     interaction.ghosts.forEach((ghost) => {
-      ghost.node.style.transform = `translate(${dx}px, ${dy}px)`;
+      ghost.node.style.transform = `translate(${snappedDx}px, ${snappedDy}px)`;
     });
   };
 
@@ -1203,12 +1212,14 @@ function startResizeInteraction(state, event, id, direction) {
     }
     const dx = evt.clientX - interaction.startX;
     const dy = evt.clientY - interaction.startY;
-    interaction.deltaX = dx;
-    interaction.deltaY = dy;
+    const snappedDx = snapToGrid(dx, state.grid.scale);
+    const snappedDy = snapToGrid(dy, state.grid.scale);
+    interaction.deltaX = snappedDx;
+    interaction.deltaY = snappedDy;
     interaction.ghosts.forEach((ghost) => {
       const { rect } = ghost;
       const frame = { left: rect.left, top: rect.top, width: rect.width, height: rect.height };
-      const updated = adjustGhostFrame(frame, dx, dy, direction);
+      const updated = adjustGhostFrame(frame, snappedDx, snappedDy, direction);
       ghost.node.style.left = `${updated.left}px`;
       ghost.node.style.top = `${updated.top}px`;
       ghost.node.style.width = `${Math.max(24, updated.width)}px`;

--- a/public/js/modules/layout.js
+++ b/public/js/modules/layout.js
@@ -1,6 +1,7 @@
-export const DEFAULT_GRID_SCALE = 48;
 export const DEFAULT_SURFACE_WIDTH = 1200;
 export const DEFAULT_SURFACE_HEIGHT = 720;
+export const DEFAULT_SURFACE_COLUMNS = 12;
+export const DEFAULT_GRID_SCALE = Math.round(DEFAULT_SURFACE_WIDTH / DEFAULT_SURFACE_COLUMNS);
 
 export function normalizeLayout(value) {
   if (value === 'stack') {
@@ -73,15 +74,25 @@ function applyRootColor(root, variable, value) {
   }
 }
 
+function resolveDimension(value, fallback) {
+  const numeric = Number(value);
+  return Number.isFinite(numeric) && numeric > 0 ? numeric : fallback;
+}
+
+function resolveGridSize(gridSize, widthFallback) {
+  const numeric = Number(gridSize);
+  if (Number.isFinite(numeric) && numeric > 0) {
+    return numeric;
+  }
+  const derived = Math.round(widthFallback / DEFAULT_SURFACE_COLUMNS);
+  return Number.isFinite(derived) && derived > 0 ? derived : DEFAULT_GRID_SCALE;
+}
+
 export function normalizeSurface(surface = {}) {
-  const width = Number(surface.width);
-  const height = Number(surface.height);
-  const gridSize = Number(surface.gridSize);
-  return {
-    width: Number.isFinite(width) && width > 0 ? width : DEFAULT_SURFACE_WIDTH,
-    height: Number.isFinite(height) && height > 0 ? height : DEFAULT_SURFACE_HEIGHT,
-    gridSize: Number.isFinite(gridSize) && gridSize > 0 ? gridSize : DEFAULT_GRID_SCALE,
-  };
+  const width = resolveDimension(surface.width, DEFAULT_SURFACE_WIDTH);
+  const height = resolveDimension(surface.height, DEFAULT_SURFACE_HEIGHT);
+  const gridSize = resolveGridSize(surface.gridSize, width);
+  return { width, height, gridSize };
 }
 
 export function getSurfaceGridSize(globals = {}, fallback = DEFAULT_GRID_SCALE) {

--- a/public/js/modules/layout.js
+++ b/public/js/modules/layout.js
@@ -13,13 +13,21 @@ export function normalizeLayout(value) {
   return 'freeform';
 }
 
+function resolveSpacing(value, fallback = 0) {
+  const numeric = Number(value);
+  if (Number.isFinite(numeric) && numeric >= 0) {
+    return numeric;
+  }
+  return fallback;
+}
+
 export function setupLayout(container, globals = {}) {
   container.className = '';
   const theme = globals.theme || {};
   const layout = normalizeLayout(theme.layout);
-  const gap = theme.gap ?? 8;
-  const margin = theme.margins ?? 12;
-  const surface = normalizeSurface(globals.surface);
+  const gap = resolveSpacing(theme.gap, 16);
+  const margin = resolveSpacing(theme.margins, 24);
+  const surface = normalizeSurface(globals.surface || {});
 
   container.dataset.layout = layout;
   container.style.padding = `${margin}px`;
@@ -82,20 +90,32 @@ function resolveDimension(value, fallback) {
 function resolveGridSize(gridSize, widthFallback) {
   const numeric = Number(gridSize);
   if (Number.isFinite(numeric) && numeric > 0) {
-    return numeric;
+    return { value: numeric, explicit: true };
   }
   const derived = Math.round(widthFallback / DEFAULT_SURFACE_COLUMNS);
-  return Number.isFinite(derived) && derived > 0 ? derived : DEFAULT_GRID_SCALE;
+  const value = Number.isFinite(derived) && derived > 0 ? derived : DEFAULT_GRID_SCALE;
+  return { value, explicit: false };
 }
 
 export function normalizeSurface(surface = {}) {
-  const width = resolveDimension(surface.width, DEFAULT_SURFACE_WIDTH);
-  const height = resolveDimension(surface.height, DEFAULT_SURFACE_HEIGHT);
-  const gridSize = resolveGridSize(surface.gridSize, width);
-  return { width, height, gridSize };
+  const width = resolveDimension(surface?.width, DEFAULT_SURFACE_WIDTH);
+  const height = resolveDimension(surface?.height, DEFAULT_SURFACE_HEIGHT);
+  const columnsCandidate = Number(surface?.columns);
+  const columns = Number.isFinite(columnsCandidate) && columnsCandidate > 0 ? columnsCandidate : DEFAULT_SURFACE_COLUMNS;
+  const grid = resolveGridSize(surface?.gridSize, width);
+  return { width, height, gridSize: grid.value, gridExplicit: grid.explicit, columns };
 }
 
 export function getSurfaceGridSize(globals = {}, fallback = DEFAULT_GRID_SCALE) {
   const surface = normalizeSurface(globals.surface || {});
+  const gap = resolveSpacing(globals?.theme?.gap, 0);
+  if (!surface.gridExplicit) {
+    const totalGap = gap * Math.max(0, (surface.columns || DEFAULT_SURFACE_COLUMNS) - 1);
+    const availableWidth = surface.width - totalGap;
+    const derived = availableWidth / Math.max(1, surface.columns || DEFAULT_SURFACE_COLUMNS);
+    if (Number.isFinite(derived) && derived > 0) {
+      return derived;
+    }
+  }
   return surface.gridSize || fallback;
 }


### PR DESCRIPTION
## Summary
- derive the default freeform grid scale from the configured surface width so runtime layouts no longer render squished
- snap editor move/resize ghosts to the active grid while preventing embedded controls from stealing pointer events during layout editing
- update the base configuration grid size so new configs adopt the wider default surface spacing

## Testing
- php -l lib/Defaults.php

------
https://chatgpt.com/codex/tasks/task_e_68d56b8130f4832d89c14bb4c1cdc903